### PR TITLE
Make config update timeout configurable, increase timeouts

### DIFF
--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -62,7 +62,7 @@ func Provider() terraform.ResourceProvider {
 			"timeout": {
 				Type:        schema.TypeInt,
 				Optional:    true,
-				Default:     90,
+				Default:     120,
 				Description: "Timeout in seconds",
 			},
 		},

--- a/kafka/resource_kafka_topic.go
+++ b/kafka/resource_kafka_topic.go
@@ -85,11 +85,12 @@ func topicUpdate(d *schema.ResourceData, meta interface{}) error {
 		}
 	}
 
+	timeout := time.Duration(c.config.Timeout) * time.Second
 	stateConf := &resource.StateChangeConf{
 		Pending:      []string{"Updating"},
 		Target:       []string{"Ready"},
 		Refresh:      topicRefreshFunc(c, d.Id(), t),
-		Timeout:      10 * time.Second,
+		Timeout:      timeout,
 		Delay:        1 * time.Second,
 		PollInterval: 1 * time.Second,
 		MinTimeout:   2 * time.Second,


### PR DESCRIPTION
* Increases the default timeout for all operations from 90s to 120s.
* Increases the default time for config changes from 10s -> 120s
* Uses provider specified timeout when waiting for config updates

Fixes #26 