### PR TITLE
Ensure config values are always strings.

### DIFF
--- a/kafka/resource_kafka_topic.go
+++ b/kafka/resource_kafka_topic.go
@@ -42,6 +42,7 @@ func kafkaTopicResource() *schema.Resource {
 				Optional:    true,
 				ForceNew:    false,
 				Description: "A map of string k/v attributes.",
+				Elem:        schema.TypeString,
 			},
 		},
 	}


### PR DESCRIPTION
If a config value contains a non-string value, Terraform will now error
with the following message.

```
Error: Error loading tmp.tf: Error reading config for kafka_topic[test]:
At 12:24: root.config[0].cleanup.policy: unknown type for string
*ast.LiteralType
```

Fixes #41 