### PR TITLE
update DescribeConfigRequest API version to default

### DIFF
--- a/kafka/client.go
+++ b/kafka/client.go
@@ -244,7 +244,6 @@ func (client *Client) ReadTopic(name string) (Topic, error) {
 func (c *Client) topicConfig(topic string) (map[string]*string, error) {
 	conf := map[string]*string{}
 	request := &sarama.DescribeConfigsRequest{
-		Version: 1,
 		Resources: []*sarama.ConfigResource{
 			{
 				Type: sarama.TopicResource,


### PR DESCRIPTION
DescribeConfigRequest API v1 is not working on Kafka 1.0.0
Error:  `java.lang.IllegalArgumentException: Invalid version for API key DESCRIBE_CONFIGS: 1`
Everything good if default version used.