### PR TITLE
Generate request version from broker information

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -32,3 +32,9 @@ jobs:
             make testacc| tee ${TEST_RESULTS}/go-test.out
       - store_test_results:
           path: /tmp/test-results
+
+workflows:
+  version: 2
+  build:
+    jobs:
+      - build

--- a/kafka/client.go
+++ b/kafka/client.go
@@ -36,10 +36,6 @@ type Config struct {
 	SASLPassword     string
 }
 
-func (c *Config) SASLEnabled() bool {
-	return c.SASLUsername != "" || c.SASLPassword != ""
-}
-
 func NewClient(config *Config) (*Client, error) {
 	log.Printf("[INFO] configuring bootstrap_servers %v", config)
 	bootstrapServers := *(config.BootstrapServers)
@@ -280,13 +276,6 @@ func (c *Client) topicConfig(topic string) (map[string]*string, error) {
 	return conf, nil
 }
 
-func isDefault(tc *sarama.ConfigEntry, version int) bool {
-	if version == 0 {
-		return tc.Default
-	}
-	return tc.Source == sarama.SourceDefault || tc.Source == sarama.SourceStaticBroker
-}
-
 func (c *Client) availableBroker() (*sarama.Broker, error) {
 	var err error
 	brokers := *c.config.BootstrapServers
@@ -309,7 +298,7 @@ func (c *Config) newKafkaConfig() (*sarama.Config, error) {
 	kafkaConfig := sarama.NewConfig()
 	kafkaConfig.Version = sarama.V1_0_0_0
 
-	if c.SASLEnabled() {
+	if c.saslEnabled() {
 		kafkaConfig.Net.SASL.Enable = true
 		kafkaConfig.Net.SASL.Password = c.SASLPassword
 		kafkaConfig.Net.SASL.User = c.SASLUsername
@@ -331,6 +320,10 @@ func (c *Config) newKafkaConfig() (*sarama.Config, error) {
 	}
 
 	return kafkaConfig, nil
+}
+
+func (c *Config) saslEnabled() bool {
+	return c.SASLUsername != "" || c.SASLPassword != ""
 }
 
 func newTLSConfig(clientCertFile, clientKeyFile, caCertFile string) (*tls.Config, error) {

--- a/kafka/client_test.go
+++ b/kafka/client_test.go
@@ -1,0 +1,28 @@
+package kafka
+
+import "testing"
+
+func Test_ClientAPIVersion(t *testing.T) {
+	// Default to 0
+	client := &Client{}
+	maxVersion := client.versionForKey(32, 1)
+	if maxVersion != 0 {
+		t.Errorf("Got %d, expected %d", maxVersion, 0)
+	}
+
+	// use the max version the broker supports, if it's less than the requested
+	// version
+	client.supportedAPIs = map[int]int{32: 0}
+	maxVersion = client.versionForKey(32, 1)
+	if maxVersion != 0 {
+		t.Errorf("Got %d, expected %d", maxVersion, 0)
+	}
+
+	// while the broker supports 2, terraform-provider-kafka only supports 1, so
+	// use that
+	client.supportedAPIs = map[int]int{32: 2}
+	maxVersion = client.versionForKey(32, 1)
+	if maxVersion != 1 {
+		t.Errorf("Got %d, expected %d", maxVersion, 1)
+	}
+}

--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -56,6 +56,13 @@ func configToResources(topic Topic) []*sarama.AlterConfigsResource {
 	}
 }
 
+func isDefault(tc *sarama.ConfigEntry, version int) bool {
+	if version == 0 {
+		return tc.Default
+	}
+	return tc.Source == sarama.SourceDefault || tc.Source == sarama.SourceStaticBroker
+}
+
 func metaToTopic(d *schema.ResourceData, meta interface{}) Topic {
 	topicName := d.Get("name").(string)
 	partitions := d.Get("partitions").(int)


### PR DESCRIPTION
This uses the broker information to see what version of `DescribeConfigRequest` to use.
Addresses #44 