### PR TITLE
allow certs to be provided as strings or file path

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,21 +5,13 @@ A [Terraform][1] plugin for managing [Apache Kafka][2].
 
 ## Contents
 
-- [`terraform-provider-kafka`](#terraform-provider-kafka)
-  - [Contents](#contents)
-  - [Installation](#installation)
-    - [Developing](#developing)
-  - [Provider Configuration](#provider-configuration)
-    - [Example](#example)
-  - [Resources](#resources)
-    - [`kafka_topic`](#kafkatopic)
-      - [Example](#example-1)
-      - [Properties](#properties)
-      - [Importing Existing Topics](#importing-existing-topics)
-    - [`kafka_acl`](#kafkaacl)
-      - [Example](#example-2)
-      - [Properties](#properties-1)
-  - [Requirements](#requirements)
+* [Installation](#installation)
+  * [Developing](#developing)
+* [`kafka` Provider](#provider-configuration)
+* [Resources](#resources)
+  * [`kafka_topic`](#kafka_topic)
+  * [`kafka_acl`](#kafka_acl)
+* [Requirements](#requirements)
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,13 +5,21 @@ A [Terraform][1] plugin for managing [Apache Kafka][2].
 
 ## Contents
 
-* [Installation](#installation)
-  * [Developing](#developing)
-* [`kafka` Provider](#provider-configuration)
-* [Resources](#resources)
-  * [`kafka_topic`](#kafka_topic)
-  * [`kafka_acl`](#kafka_acl)
-* [Requirements](#requirements)
+- [`terraform-provider-kafka`](#terraform-provider-kafka)
+  - [Contents](#contents)
+  - [Installation](#installation)
+    - [Developing](#developing)
+  - [Provider Configuration](#provider-configuration)
+    - [Example](#example)
+  - [Resources](#resources)
+    - [`kafka_topic`](#kafkatopic)
+      - [Example](#example-1)
+      - [Properties](#properties)
+      - [Importing Existing Topics](#importing-existing-topics)
+    - [`kafka_acl`](#kafkaacl)
+      - [Example](#example-2)
+      - [Properties](#properties-1)
+  - [Requirements](#requirements)
 
 ## Installation
 
@@ -40,24 +48,24 @@ Example provider with SSL client authentication.
 ```hcl
 provider "kafka" {
   bootstrap_servers = ["localhost:9092"]
-  ca_cert_file      = "../secrets/snakeoil-ca-1.crt"
-  client_cert_file  = "../secrets/kafkacat-ca1-signed.pem"
-  client_key_file   = "../secrets/kafkacat-raw-private-key.pem"
+  ca_cert      = file("../secrets/snakeoil-ca-1.crt")
+  client_cert  = file("../secrets/kafkacat-ca1-signed.pem")
+  client_key   = file("../secrets/kafkacat-raw-private-key.pem")
   skip_tls_verify   = true
 }
 ```
 
-| Property            | Description                                                                                      | Default    |
-| ----------------    | -----------------------                                                                          | ---------- |
-| `bootstrap_servers` | A list of host:port addresses that will be used to discover the full set of alive brokers        | `Required` |
-| `ca_cert_file`      | The path to a CA certificate file to validate the server's certificate.                          | `""`       |
-| `client_cert_file`  | The path to a file containing the client certificate -- Use for Client authentication to Kafka.  | `""`       |
-| `client_key_file`   | Path to a file containing the private key that the client certificate was issued for.            | `""`       |
-| `skip_tls_verify`   | Skip TLS verification.                                                                           | `false`    |
-| `tls_enabled`       | Enable communication with the Kafka Cluster over TLS.                                            | `false`    |
-| `sasl_username`     | Username for SASL authentication.                                                                | `""`       |
-| `sasl_password`     | Password for SASL authentication.                                                                | `""`       |
-| `sasl_mechanism`    | Mechanism for SASL authentication. Allowed values are plain, scram-sha512 and scram-sha256       | `plain`    |
+| Property            | Description                                                                                                           | Default    |
+| ------------------- | --------------------------------------------------------------------------------------------------------------------- | ---------- |
+| `bootstrap_servers` | A list of host:port addresses that will be used to discover the full set of alive brokers                             | `Required` |
+| `ca_cert`           | The CA certificate or path to a CA certificate file to validate the server's certificate.                             | `""`       |
+| `client_cert`       | The client certificate or path to a file containing the client certificate -- Use for Client authentication to Kafka. | `""`       |
+| `client_key`        | The private key or path to a file containing the private key that the client certificate was issued for.              | `""`       |
+| `skip_tls_verify`   | Skip TLS verification.                                                                                                | `false`    |
+| `tls_enabled`       | Enable communication with the Kafka Cluster over TLS.                                                                 | `false`    |
+| `sasl_username`     | Username for SASL authentication.                                                                                     | `""`       |
+| `sasl_password`     | Password for SASL authentication.                                                                                     | `""`       |
+| `sasl_mechanism`    | Mechanism for SASL authentication. Allowed values are plain, scram-sha512 and scram-sha256                            | `plain`    |
 
 ## Resources
 ### `kafka_topic`
@@ -87,9 +95,9 @@ resource "kafka_topic" "logs" {
 #### Properties
 
 | Property             | Description                                    |
-| ----------------     | -----------------------                        |
+| -------------------- | ---------------------------------------------- |
 | `name`               | The name of the topic                          |
-| `partitions`          | The number of partitions the topic should have |
+| `partitions`         | The number of partitions the topic should have |
 | `replication_factor` | The number of replicas the topic should have   |
 | `config`             | A map of string k/v attributes                 |
 
@@ -110,9 +118,9 @@ A resource for managing Kafka ACLs.
 ```hcl
 provider "kafka" {
   bootstrap_servers = ["localhost:9092"]
-  ca_cert_file      = "../secrets/snakeoil-ca-1.crt"
-  client_cert_file  = "../secrets/kafkacat-ca1-signed.pem"
-  client_key_file   = "../secrets/kafkacat-raw-private-key.pem"
+  ca_cert      = file("../secrets/snakeoil-ca-1.crt")
+  client_cert  = file("../secrets/kafkacat-ca1-signed.pem")
+  client_key   = file("../secrets/kafkacat-raw-private-key.pem")
   skip_tls_verify   = true
 }
 
@@ -128,15 +136,15 @@ resource "kafka_acl" "test" {
 
 #### Properties
 
-| Property              | Description                                                        | Valid values                                                     |
-| ----------------      | ----------------------                                             | --------------                                                   |
-| `acl_host`            | Host from which principal listed in acl_principal will have access | `*`                                                              |
-| `acl_operation`       | Operation that is being allowed or denied                          | `Unknown`, `Any`, `All`, `Read`, `Write`, `Create`, `Delete`, `Alter`, `Describe`, `ClusterAction`, `DescribeConfigs`, `AlterConfigs`, `IdempotentWrite` |
-| `acl_permission_type` | Type of permission                                                 | `Unknown`, `Any`, `Allow`, `Deny`                                |
-| `acl_principal`       | Principal that is being allowed or denied                          | `*`                                                              |
-| `resource_name`       | The name of the resource                                           | `*`                                                              |
-| `resource_type`       | The type of resource                                               | `Unknown`, `Any`, `Topic`, `Group`, `Cluster`, `TransactionalID` |
-| `resource_pattern_type_filter`       |                                                     | `Prefixed`, `Any`, `Match`, `Literal` |
+| Property                       | Description                                                        | Valid values                                                                                                                                             |
+| ------------------------------ | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `acl_host`                     | Host from which principal listed in acl_principal will have access | `*`                                                                                                                                                      |
+| `acl_operation`                | Operation that is being allowed or denied                          | `Unknown`, `Any`, `All`, `Read`, `Write`, `Create`, `Delete`, `Alter`, `Describe`, `ClusterAction`, `DescribeConfigs`, `AlterConfigs`, `IdempotentWrite` |
+| `acl_permission_type`          | Type of permission                                                 | `Unknown`, `Any`, `Allow`, `Deny`                                                                                                                        |
+| `acl_principal`                | Principal that is being allowed or denied                          | `*`                                                                                                                                                      |
+| `resource_name`                | The name of the resource                                           | `*`                                                                                                                                                      |
+| `resource_type`                | The type of resource                                               | `Unknown`, `Any`, `Topic`, `Group`, `Cluster`, `TransactionalID`                                                                                         |
+| `resource_pattern_type_filter` |                                                                    | `Prefixed`, `Any`, `Match`, `Literal`                                                                                                                    |
 
 
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ Example provider with SSL client authentication.
 ```hcl
 provider "kafka" {
   bootstrap_servers = ["localhost:9092"]
-  ca_cert      = file("../secrets/snakeoil-ca-1.crt")
-  client_cert  = file("../secrets/kafkacat-ca1-signed.pem")
-  client_key   = file("../secrets/kafkacat-raw-private-key.pem")
+  ca_cert           = file("../secrets/snakeoil-ca-1.crt")
+  client_cert       = file("../secrets/kafkacat-ca1-signed.pem")
+  client_key        = file("../secrets/kafkacat-raw-private-key.pem")
   skip_tls_verify   = true
 }
 ```

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -17,19 +17,19 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				Description: "A list of kafka brokers",
 			},
-			"ca_cert_file": &schema.Schema{
+			"ca_cert": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CA_CERT", ""),
 				Description: "Path to a CA certificate file to validate the server's certificate.",
 			},
-			"client_cert_file": &schema.Schema{
+			"client_cert": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CLIENT_CERT", ""),
 				Description: "Path to a file containing the client certificate.",
 			},
-			"client_key_file": &schema.Schema{
+			"client_key": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CLIENT_KEY", ""),
@@ -98,9 +98,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	config := &Config{
 		BootstrapServers: brokers,
-		CACertFile:       d.Get("ca_cert_file").(string),
-		ClientCertFile:   d.Get("client_cert_file").(string),
-		ClientCertKey:    d.Get("client_key_file").(string),
+		CACert:           d.Get("ca_cert").(string),
+		ClientCert:       d.Get("client_cert").(string),
+		ClientCertKey:    d.Get("client_key").(string),
 		SkipTLSVerify:    d.Get("skip_tls_verify").(bool),
 		SASLUsername:     d.Get("sasl_username").(string),
 		SASLPassword:     d.Get("sasl_password").(string),

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -21,19 +21,19 @@ func Provider() terraform.ResourceProvider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CA_CERT", ""),
-				Description: "Path to a CA certificate file to validate the server's certificate.",
+				Description: "CA certificate file to validate the server's certificate.",
 			},
 			"client_cert": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CLIENT_CERT", ""),
-				Description: "Path to a file containing the client certificate.",
+				Description: "The client certificate.",
 			},
 			"client_key": &schema.Schema{
 				Type:        schema.TypeString,
 				Required:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CLIENT_KEY", ""),
-				Description: "Path to a file containing the private key that the certificate was issued for.",
+				Description: "The private key that the certificate was issued for.",
 			},
 			"sasl_username": &schema.Schema{
 				Type:        schema.TypeString,

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -17,6 +17,27 @@ func Provider() terraform.ResourceProvider {
 				Required:    true,
 				Description: "A list of kafka brokers",
 			},
+			"ca_cert_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CA_CERT", ""),
+				Description: "Path to a CA certificate file to validate the server's certificate.",
+				Deprecated:  "This parameter is now deprecated and will be removed in a later release, please use `ca_cert` instead.",
+			},
+			"client_cert_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CLIENT_CERT", ""),
+				Description: "Path to a file containing the client certificate.",
+				Deprecated:  "This parameter is now deprecated and will be removed in a later release, please use `client_cert` instead.",
+			},
+			"client_key_file": &schema.Schema{
+				Type:        schema.TypeString,
+				Required:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CLIENT_KEY", ""),
+				Description: "Path to a file containing the private key that the certificate was issued for.",
+				Deprecated:  "This parameter is now deprecated and will be removed in a later release, please use `client_key` instead.",
+			},
 			"ca_cert": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -107,6 +128,16 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SASLMechanism:    saslMechanism,
 		TLSEnabled:       d.Get("tls_enabled").(bool),
 		Timeout:          d.Get("timeout").(int),
+	}
+
+	if config.CACert == "" {
+		config.CACert = d.Get("ca_cert_file").(string)
+	}
+	if config.ClientCert == "" {
+		config.ClientCert = d.Get("client_cert_file").(string)
+	}
+	if config.ClientCertKey == "" {
+		config.ClientCertKey = d.Get("client_key_file").(string)
 	}
 
 	log.Printf("[DEBUG] Config @ %v", config)

--- a/kafka/resource_kafka_acl_test.go
+++ b/kafka/resource_kafka_acl_test.go
@@ -146,9 +146,9 @@ func testResourceACL_updateCheck(s *terraform.State) error {
 const testResourceACL_initialConfig = `
 provider "kafka" {
   bootstrap_servers = ["localhost:9092"]
-	ca_cert_file      = "../secrets/snakeoil-ca-1.crt"
-	client_cert_file = "../secrets/kafkacat-ca1-signed.pem"
-	client_key_file  = "../secrets/kafkacat-raw-private-key.pem"
+	ca_cert           = file("../secrets/snakeoil-ca-1.crt")
+	client_cert       = file("../secrets/kafkacat-ca1-signed.pem")
+	client_key        = file("../secrets/kafkacat-raw-private-key.pem")
 	skip_tls_verify   = true
 }
 
@@ -166,9 +166,9 @@ resource "kafka_acl" "test" {
 const testResourceACL_updateConfig = `
 provider "kafka" {
   bootstrap_servers = ["localhost:9092"]
-	ca_cert_file      = "../secrets/snakeoil-ca-1.crt"
-	client_cert_file = "../secrets/kafkacat-ca1-signed.pem"
-	client_key_file  = "../secrets/kafkacat-raw-private-key.pem"
+	ca_cert           = file("../secrets/snakeoil-ca-1.crt")
+	client_cert       = file("../secrets/kafkacat-ca1-signed.pem")
+	client_key        = file("../secrets/kafkacat-raw-private-key.pem")
 	skip_tls_verify   = true
 }
 


### PR DESCRIPTION
to allow for more use cases, such as if cert was stored in vault