### PR TITLE
Handle usecase when kafka returns ErrUnknownTopicOrPartition error gracefully

### DIFF
--- a/kafka/client.go
+++ b/kafka/client.go
@@ -210,6 +210,9 @@ func (client *Client) ReadTopic(name string) (Topic, error) {
 
 	err := c.RefreshMetadata(name)
 	if err != nil {
+		if err == sarama.ErrUnknownTopicOrPartition {
+			return topic, TopicMissingError{msg: fmt.Sprintf("%s", err)}
+		}
 		log.Printf("[ERROR] Error refreshing metadata %s", err)
 		return topic, err
 	}


### PR DESCRIPTION
The error: 
```
2019-11-21T16:51:42.498+0100 [DEBUG] plugin.terraform-provider-kafka: 2019/11/21 16:51:42 [ERROR] Error refreshing metadata kafka server: Request was for a topic or partition that does not exist on this broker.
2019-11-21T16:51:42.498+0100 [DEBUG] plugin.terraform-provider-kafka: 2019/11/21 16:51:42 [ERROR] Error getting topics kafka server: Request was for a topic or partition that does not exist on this broker. from Kafka
2019/11/21 16:51:42 [ERROR] root: eval: *terraform.EvalRefresh, err: kafka_topic.test_topic: kafka server: Request was for a topic or partition that does not exist on this broker.
2019/11/21 16:51:42 [ERROR] root: eval: *terraform.EvalSequence, err: kafka_topic.test_topic: kafka server: Request was for a topic or partition that does not exist on this broker.
2019/11/21 16:51:42 [TRACE] [walkRefresh] Exiting eval tree: kafka_topic.test_topic
```