### PR TITLE
Stop calling RefreshMetadata for ACLs.

### DIFF
--- a/kafka/kafka_acls.go
+++ b/kafka/kafka_acls.go
@@ -262,10 +262,6 @@ func (c *Client) ListACLs() ([]*sarama.ResourceAcls, error) {
 	if err != nil {
 		return nil, err
 	}
-	err = c.client.RefreshMetadata()
-	if err != nil {
-		return nil, err
-	}
 
 	allResources := []*sarama.DescribeAclsRequest{
 		&sarama.DescribeAclsRequest{
@@ -307,8 +303,11 @@ func (c *Client) ListACLs() ([]*sarama.ResourceAcls, error) {
 	}
 	res := []*sarama.ResourceAcls{}
 
+	log.Printf("[TRACE] Asking Kafka for all the resources")
 	for _, r := range allResources {
+		log.Printf("[TRACE] Describe Acl Requst %v", r)
 		aclsR, err := broker.DescribeAcls(r)
+		log.Printf("[TRACE] ThrottleTime: %d", aclsR.ThrottleTime)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
When there are a lot of ACLs, Kafka or Sarama may not respond for a
while when calling RefreshMetadata a lot.
Seen when querying for 500 ACLs on CC.