### PR TITLE
Server side config check

### DIFF
--- a/kafka/lazy_client.go
+++ b/kafka/lazy_client.go
@@ -24,6 +24,14 @@ func (c *LazyClient) init() error {
 	return err
 }
 
+func (c *LazyClient) CheckConfigDiff(t Topic) error {
+	err := c.init()
+	if err != nil {
+		return err
+	}
+	return c.inner.CheckConfigDiff(t)
+}
+
 func (c *LazyClient) CreateTopic(t Topic) error {
 	err := c.init()
 	if err != nil {

--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"errors"
 	"fmt"
+	"log"
 
 	"github.com/Shopify/sarama"
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
@@ -64,6 +65,31 @@ func isDefault(tc *sarama.ConfigEntry, version int) bool {
 }
 
 func metaToTopic(d *schema.ResourceData, meta interface{}) Topic {
+	log.Printf("meta = %+v", meta)
+	topicName := d.Get("name").(string)
+	partitions := d.Get("partitions").(int)
+	replicationFactor := d.Get("replication_factor").(int)
+	convertedPartitions := int32(partitions)
+	convertedRF := int16(replicationFactor)
+	config := d.Get("config").(map[string]interface{})
+
+	m2 := make(map[string]*string)
+	for key, value := range config {
+		switch value := value.(type) {
+		case string:
+			m2[key] = &value
+		}
+	}
+
+	return Topic{
+		Name:              topicName,
+		Partitions:        convertedPartitions,
+		ReplicationFactor: convertedRF,
+		Config:            m2,
+	}
+}
+
+func diffToTopic(d *schema.ResourceDiff, meta interface{}) Topic {
 	topicName := d.Get("name").(string)
 	partitions := d.Get("partitions").(int)
 	replicationFactor := d.Get("replication_factor").(int)


### PR DESCRIPTION
Supersedes #135
Addresses #134

This uses a "dry-run" approach to try to determine if the server will require the topic to be recreated.  Unfortunately, the server returns INVALID_CONFIG with an error message describing that the topic will need to be recreated so this just matches on the string "create a new topic" which is probably too brittle to make this useful in cases other than my specific case.

This does catch some errors at plan time that would otherwise only be caught at apply time, so it's still somewhat useful in general.

Note: diffToTopic and metaToTopic are identical except for the input type...  I'm not sure how to make a function accept multiple types...  It may have something to do with an interface, but I'm not sure.