### PR TITLE
Fix nil dereference error in kafka_acl plan

### DIFF
--- a/kafka/kafka_acls.go
+++ b/kafka/kafka_acls.go
@@ -421,10 +421,11 @@ func (c *Client) ListACLs() ([]*sarama.ResourceAcls, error) {
 	for _, r := range allResources {
 		log.Printf("[TRACE] Describe Acl Requst %v", r)
 		aclsR, err := broker.DescribeAcls(r)
-		log.Printf("[TRACE] ThrottleTime: %d", aclsR.ThrottleTime)
 		if err != nil {
 			return nil, err
 		}
+		
+		log.Printf("[TRACE] ThrottleTime: %d", aclsR.ThrottleTime)
 
 		if err == nil {
 			if aclsR.Err != sarama.ErrNoError {


### PR DESCRIPTION
This fixes a nil dereference segfault on kafka_acl plan in some scenarios:

```
Stack trace from the terraform-provider-kafka_v0.4.0 plugin:

panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0xeef939]

goroutine 41 [running]:
github.com/Mongey/terraform-provider-kafka/kafka.(*Client).ListACLs(0xc0005b2450, 0x0, 0x0, 0x0, 0x0, 0x6b)
	/home/runner/work/terraform-provider-kafka/terraform-provider-kafka/kafka/kafka_acls.go:424 +0x499
github.com/Mongey/terraform-provider-kafka/kafka.(*LazyClient).ListACLs(0xc00057f890, 0x15, 0xc0006436f0, 0x1, 0x1, 0xc000042718)
	/home/runner/work/terraform-provider-kafka/terraform-provider-kafka/kafka/lazy_client.go:138 +0x79
github.com/Mongey/terraform-provider-kafka/kafka.aclRead(0x13ba598, 0xc000495080, 0xc000304b80, 0x10cbfe0, 0xc00057f890, 0xc00011ac40, 0xc000643908, 0x40e0f8)
	/home/runner/work/terraform-provider-kafka/terraform-provider-kafka/kafka/resource_kafka_acl.go:101 +0x185
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).read(0xc000136620, 0x13ba528, 0xc0001b8980, 0xc000304b80, 0x10cbfe0, 0xc00057f890, 0x0, 0x0, 0x0)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.1/helper/schema/resource.go:347 +0x17f
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*Resource).RefreshWithoutUpgrade(0xc000136620, 0x13ba528, 0xc0001b8980, 0xc000327880, 0x10cbfe0, 0xc00057f890, 0xc0000b3000, 0x0, 0x0, 0x0)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.1/helper/schema/resource.go:624 +0x1cb
github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema.(*GRPCProviderServer).ReadResource(0xc0000a9698, 0x13ba528, 0xc0001b8980, 0xc0001b89c0, 0xc0001b8980, 0x40b965, 0x109c440)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-sdk/v2@v2.7.1/helper/schema/grpc_provider.go:575 +0x43b
github.com/hashicorp/terraform-plugin-go/tfprotov5/server.(*server).ReadResource(0xc0005f3380, 0x13ba5d0, 0xc0001b8980, 0xc000494540, 0xc0005f3380, 0xc00014a150, 0xc000639ba0)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/server/server.go:298 +0x105
github.com/hashicorp/terraform-plugin-go/tfprotov5/internal/tfplugin5._Provider_ReadResource_Handler(0x10e3020, 0xc0005f3380, 0x13ba5d0, 0xc00014a150, 0xc0004944e0, 0x0, 0x13ba5d0, 0xc00014a150, 0xc0000d0580, 0x158)
	/home/runner/go/pkg/mod/github.com/hashicorp/terraform-plugin-go@v0.3.0/tfprotov5/internal/tfplugin5/tfplugin5_grpc.pb.go:344 +0x214
google.golang.org/grpc.(*Server).processUnaryRPC(0xc00031c540, 0x13c5598, 0xc0000b7800, 0xc00012c900, 0xc00057e930, 0x199b030, 0x0, 0x0, 0x0)
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.34.0/server.go:1210 +0x52b
google.golang.org/grpc.(*Server).handleStream(0xc00031c540, 0x13c5598, 0xc0000b7800, 0xc00012c900, 0x0)
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.34.0/server.go:1533 +0xd0c
google.golang.org/grpc.(*Server).serveStreams.func1.2(0xc000042200, 0xc00031c540, 0x13c5598, 0xc0000b7800, 0xc00012c900)
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.34.0/server.go:871 +0xab
created by google.golang.org/grpc.(*Server).serveStreams.func1
	/home/runner/go/pkg/mod/google.golang.org/grpc@v1.34.0/server.go:869 +0x1fd

```

Note that an unnecessary `if err == nil` was left in place in order to minimize the change surface, but it should be removed for clarity.