### PR TITLE
Fix remove acls when not exist

### DIFF
--- a/kafka/kafka_acls.go
+++ b/kafka/kafka_acls.go
@@ -160,18 +160,12 @@ func (c *Client) DeleteACL(s StringlyTypedACL) error {
 		return err
 	}
 
-	matchingAclCount := 0
-
 	for _, r := range res.FilterResponses {
-		matchingAclCount += len(r.MatchingAcls)
 		if r.Err != sarama.ErrNoError {
 			return r.Err
 		}
 	}
 
-	if matchingAclCount == 0 {
-		return fmt.Errorf("There were no acls matching this filter")
-	}
 	return nil
 }
 
@@ -424,7 +418,7 @@ func (c *Client) ListACLs() ([]*sarama.ResourceAcls, error) {
 		if err != nil {
 			return nil, err
 		}
-		
+
 		log.Printf("[TRACE] ThrottleTime: %d", aclsR.ThrottleTime)
 
 		if err == nil {

--- a/kafka/kafka_acls.go
+++ b/kafka/kafka_acls.go
@@ -165,7 +165,6 @@ func (c *Client) DeleteACL(s StringlyTypedACL) error {
 			return r.Err
 		}
 	}
-
 	return nil
 }
 


### PR DESCRIPTION
Closes #237 

When the ACL has already been removed from kafka, and terraform destroy is executed, the error occurs:

```
Error: There were no acls matching this filter
```

This suggestion is to avoid this error