### PR TITLE
[WIP] Introduce AWS IAM authentication

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.16
 
 require (
 	github.com/Shopify/sarama v1.32.0
+	github.com/aws/aws-sdk-go v1.43.35
 	github.com/hashicorp/go-cty v1.4.1-0.20200414143053-d3edf31b6320
 	github.com/hashicorp/go-uuid v1.0.2
 	github.com/hashicorp/terraform-plugin-docs v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -36,6 +36,10 @@ github.com/apparentlymart/go-textseg/v13 v13.0.0/go.mod h1:ZK2fH7c4NqDTLtiYLvIkE
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310 h1:BUAU3CGlLvorLI26FmByPp2eC2qla6E1Tw+scpcg/to=
 github.com/armon/go-radix v0.0.0-20180808171621-7fddfc383310/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
 github.com/armon/go-socks5 v0.0.0-20160902184237-e75332964ef5/go.mod h1:wHh0iHkYZB8zMSxRWpUBQtwG5a7fFgvEO+odwuTv2gs=
+github.com/aws/aws-sdk-go v1.43.34 h1:8+P+773CDgQqN1eLH1QHT6XgXHUbME3sAbDGszzjajY=
+github.com/aws/aws-sdk-go v1.43.34/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
+github.com/aws/aws-sdk-go v1.43.35 h1:Ko1HiU7c7C8cZ5nvwp4GoLl08nmdQtZVZHxhrD8icwk=
+github.com/aws/aws-sdk-go v1.43.35/go.mod h1:y4AeaBuwd2Lk+GepC1E9v0qOiTws0MIWAX4oIKwKHZo=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/census-instrumentation/opencensus-proto v0.2.1/go.mod h1:f6KPmirojxKA12rnyqOA5BBL4O983OfeGPqjHWSTneU=
@@ -193,6 +197,9 @@ github.com/jcmturner/rpc/v2 v2.0.3/go.mod h1:VUJYCIDm3PVOEHw8sgt091/20OJjskO/YJk
 github.com/jessevdk/go-flags v1.5.0/go.mod h1:Fw0T6WPc1dYxT4mKEZRfG5kJhaTDP9pj1c2EWnYs/m4=
 github.com/jhump/protoreflect v1.6.0 h1:h5jfMVslIg6l29nsMs0D8Wj17RDVdNYti0vDN/PZZoE=
 github.com/jhump/protoreflect v1.6.0/go.mod h1:eaTn3RZAmMBcV0fifFvlm6VHNz3wSkYyXYWUh7ymB74=
+github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
+github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
+github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351 h1:DowS9hvgyYSX4TO5NpyC606/Z4SxnNYbT+WX27or6Ck=
 github.com/kevinburke/ssh_config v0.0.0-20201106050909-4977a11b4351/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/klauspost/compress v1.14.4 h1:eijASRJcobkVtSt81Olfh7JX43osYLwy5krOJo6YEu4=
@@ -443,6 +450,7 @@ gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRN
 gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.3/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -61,6 +61,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_CLIENT_KEY_PASSPHRASE", nil),
 				Description: "The passphrase for the private key that the certificate was issued for.",
 			},
+			"sasl_aws_region": &schema.Schema{
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("KAFKA_SASL_IAM_AWS_REGION", nil),
+				Description: "AWS region where MSK is deployed.",
+			},
 			"sasl_username": &schema.Schema{
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -77,7 +83,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("KAFKA_SASL_MECHANISM", "plain"),
-				Description: "SASL mechanism, can be plain, scram-sha512, scram-sha256",
+				Description: "SASL mechanism, can be plain, scram-sha512, scram-sha256, aws-iam",
 			},
 			"skip_tls_verify": &schema.Schema{
 				Type:        schema.TypeBool,
@@ -118,9 +124,9 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 
 	saslMechanism := d.Get("sasl_mechanism").(string)
 	switch saslMechanism {
-	case "scram-sha512", "scram-sha256", "plain":
+	case "scram-sha512", "scram-sha256", "aws-iam", "plain":
 	default:
-		return nil, fmt.Errorf("[ERROR] Invalid sasl mechanism \"%s\": can only be \"scram-sha256\", \"scram-sha512\" or \"plain\"", saslMechanism)
+		return nil, fmt.Errorf("[ERROR] Invalid sasl mechanism \"%s\": can only be \"scram-sha256\", \"scram-sha512\", \"aws-iam\" or \"plain\"", saslMechanism)
 	}
 
 	config := &Config{
@@ -130,6 +136,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ClientCertKey:           d.Get("client_key").(string),
 		ClientCertKeyPassphrase: d.Get("client_key_passphrase").(string),
 		SkipTLSVerify:           d.Get("skip_tls_verify").(bool),
+		SASLAWSRegion:           d.Get("sasl_aws_region").(string),
 		SASLUsername:            d.Get("sasl_username").(string),
 		SASLPassword:            d.Get("sasl_password").(string),
 		SASLMechanism:           saslMechanism,

--- a/kafka/sasl_iam_client.go
+++ b/kafka/sasl_iam_client.go
@@ -1,0 +1,161 @@
+package kafka
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/credentials/ec2rolecreds"
+	"github.com/aws/aws-sdk-go/aws/ec2metadata"
+	"github.com/aws/aws-sdk-go/aws/session"
+	sign "github.com/aws/aws-sdk-go/aws/signer/v4"
+)
+
+type State int
+
+const (
+	SEND_CLIENT_FIRST_MESSAGE State = iota
+	RECEIVE_SERVER_RESPONSE
+	COMPLETE
+	FAILED
+)
+
+const SASLTypeAWSIAM string = "AWS_MSK_IAM"
+
+type IAMSaslClient struct {
+	brokerHost string 
+	state      State
+	region     string
+	userAgent  string
+}
+
+type AuthResponse struct {
+	Version   string `json:"version"`
+	RequestId string `json:"request-id"`
+}
+
+func (x *IAMSaslClient) CreateAuthPayload(creds *credentials.Credentials) ([]byte, error) {
+	// about sigv4 signing: https://docs.aws.amazon.com/general/latest/gr/sigv4_signing.html
+	// python example: https://docs.aws.amazon.com/general/latest/gr/sigv4-signed-request-examples.html
+
+	service := "kafka-cluster"
+
+	// prepare a standard request for presign (using query string)
+	v := url.Values{
+		"action": {service + ":Connect"},
+	}
+	u := url.URL{
+		Host: "kakfa://" + x.brokerHost,
+		Path: "/",
+		RawQuery: v.Encode(),
+	}
+	req, err := http.NewRequest("GET", u.String(), nil)
+	if err != nil {
+		return nil, fmt.Errorf("GenerateClientMessage: failed preparing HTTP request to be signed: %w", err)
+	}
+	
+	// sign request using query string
+	signer := sign.NewSigner(creds)
+	headers, err := signer.Presign(req, nil, service, x.region, 15 * time.Minute, time.Now().UTC())
+	if err != nil {
+		return nil, fmt.Errorf("GenerateClientMessage: failed presigning HTTP request: %w", err)
+	}
+
+	// prepare payload without x-amz headers
+	payload := map[string]string{
+		"version": "2020_10_22",
+		"host": x.brokerHost,
+		"user-agent": x.userAgent,
+		"action": service + ":Connect",
+	}
+
+	// add x-amz headers in the payload
+	for k, v := range headers {
+		payload[strings.ToLower(k)] = v[0]
+	}
+
+	return json.Marshal(payload)
+}
+
+func (x *IAMSaslClient) GenerateClientMessage() (response string, err error) {
+	creds := credentials.NewChainCredentials(
+		[]credentials.Provider{
+			&credentials.EnvProvider{},
+			&ec2rolecreds.EC2RoleProvider{Client: ec2metadata.New(session.New(&aws.Config{Region: &x.region}))},
+		})
+	
+	if err != nil {
+		return "", fmt.Errorf("GenerateClientMessage: failed getting AWS credentials: %w", err)
+	}
+
+	payload, err := x.CreateAuthPayload(creds)
+	if err != nil {
+		return "", fmt.Errorf("GenerateClientMessage: failed creating MSK IAM payload: %w", err)
+	}
+
+	return string(payload), nil
+}
+
+func (x *IAMSaslClient) Begin(userName, password, authzID string) (err error) {
+	if x.brokerHost == "" {
+		return errors.New("Begin: The MSK broker hostname could not be an empty value.")
+	}
+
+	if x.region == "" {
+		return errors.New("Begin: The AWS region could not be an empty value.")
+	}
+
+	if x.userAgent == "" {
+		x.userAgent = "sasl-iam-client-terraform-kafka-provider"
+	}
+	x.state = SEND_CLIENT_FIRST_MESSAGE
+	return nil
+}
+
+func (x *IAMSaslClient) Step(challenge string) (response string, err error) {
+	switch x.state {
+	case SEND_CLIENT_FIRST_MESSAGE:
+		// generate client message
+		if challenge != "" {
+			// we expect empty challenge at the beginning of the auth flow
+			return "", fmt.Errorf("Step expects an empty challenge in state 'SEND_CLIENT_FIRST_MESSAGE'")
+		}
+		response, err = x.GenerateClientMessage()
+		if err != nil {
+			x.state = FAILED
+			return "", err
+		}
+		x.state = RECEIVE_SERVER_RESPONSE
+	case RECEIVE_SERVER_RESPONSE:
+		// we expect non-empty challenge
+		if challenge == "" {
+			// we expect non-empty challenge from server response
+			x.state = FAILED
+			return "", fmt.Errorf("Step expects a non-empty authentication response in state 'RECEIVE_SERVER_RESPONSE'")
+		}
+
+		// decode response
+		var authResponse AuthResponse
+		if err := json.NewDecoder(strings.NewReader(challenge)).Decode(&authResponse); err != nil {
+			x.state = FAILED
+			return "", fmt.Errorf("Response from broker server is not a valid JSON.")
+		}
+		log.Printf("[DEBUG] SASL IAM auth response from server: Version=%s, RequestId=%s", authResponse.Version, authResponse.RequestId)
+		x.state = COMPLETE
+	default:
+		return "", errors.New("Challenge received in unexpected state")
+	}
+	
+	return response, nil
+}
+
+func (x *IAMSaslClient) Done() bool {
+	return x.state == COMPLETE
+}


### PR DESCRIPTION
AWS MSK provides a custom authentication method that is fully integrated with AWS IAM: https://docs.aws.amazon.com/msk/latest/developerguide/iam-access-control.html

This auth method has a big advantage for AWS customers: it allows to manage auth/authz with IAM policies.

I implemented a new `sarama.SCRAMClient` based on the [library developed by AWS](https://github.com/aws/aws-msk-iam-auth) to provide IAM auth for Java applications. The ["Details" section](https://github.com/aws/aws-msk-iam-auth#details) in the README helped me to understand better how to build the payload during SASL workflow.

Closes #218 