### PR TITLE
fix: aclRead does not read PatternType of acl already in Kafka

### DIFF
--- a/kafka/kafka_acls.go
+++ b/kafka/kafka_acls.go
@@ -115,20 +115,6 @@ func stringToACLPrefix(s string) sarama.AclResourcePatternType {
 	return unknownConversion
 }
 
-func resourcePatternToString(p sarama.AclResourcePatternType) string {
-	switch p {
-	case sarama.AclPatternAny:
-		return "Any"
-	case sarama.AclPatternMatch:
-		return "Match"
-	case sarama.AclPatternLiteral:
-		return "Literal"
-	case sarama.AclPatternPrefixed:
-		return "Prefixed"
-	}
-	return "unknownConversion"
-}
-
 func (c *Client) DeleteACL(s StringlyTypedACL) error {
 	log.Printf("[INFO] Deleting ACL %v", s)
 	broker, err := c.client.Controller()
@@ -424,7 +410,7 @@ func (c *Client) ListACLs() ([]*sarama.ResourceAcls, error) {
 		if err != nil {
 			return nil, err
 		}
-		
+
 		log.Printf("[TRACE] ThrottleTime: %d", aclsR.ThrottleTime)
 
 		if err == nil {

--- a/kafka/resource_kafka_acl.go
+++ b/kafka/resource_kafka_acl.go
@@ -134,21 +134,6 @@ func aclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 			if a.String() == aclID.String() {
 				return nil
 			}
-
-			// partial match -> update state
-			if a.ACL.Principal == aclID.ACL.Principal &&
-				a.ACL.Operation == aclID.ACL.Operation {
-				aclNotFound = false
-				errSet := errSetter{d: d}
-				errSet.Set("acl_principal", acl.Principal)
-				errSet.Set("acl_host", acl.Host)
-				errSet.Set("acl_operation", ACLOperationToString(acl.Operation))
-				errSet.Set("acl_permission_type", ACLPermissionTypeToString(acl.PermissionType))
-				errSet.Set("resource_pattern_type_filter", resourcePatternToString(foundACLs.ResourcePatternType))
-				if errSet.err != nil {
-					return diag.FromErr(err)
-				}
-			}
 		}
 	}
 

--- a/kafka/resource_kafka_acl.go
+++ b/kafka/resource_kafka_acl.go
@@ -124,8 +124,9 @@ func aclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 					PermissionType: ACLPermissionTypeToString(acl.PermissionType),
 				},
 				Resource: Resource{
-					Type: ACLResourceToString(foundACLs.ResourceType),
-					Name: foundACLs.ResourceName,
+					Type:              ACLResourceToString(foundACLs.ResourceType),
+					Name:              foundACLs.ResourceName,
+					PatternTypeFilter: foundACLs.ResourcePatternType.String(),
 				},
 			}
 


### PR DESCRIPTION
This is related to my issue #285 - disclaimer: I'm not really a go/terraform dev

Digging around the code I've discovered that the method `aclRead` does not set the `PatternType` (`Literal`, `Prefix`, ...) for the acls returned by kafka (maybe it's intentional? i don't know, looks wrong to me).
In the sample manifest from my issue, the ACL from Kafka (`aclID.String()`) is serialized to the following string:
```
User:CN=user|192.168.1.2|Read|Allow|Topic|test_topic|
```
While the ACL read from the state (`a.String()`) is: 
```
User:CN=user|192.168.1.2|Read|Allow|Topic|test_topic|Literal
```
Because of this, when comparing the two acls, the `exact match` [check](https://github.com/Mongey/terraform-provider-kafka/blob/55b7619d34970cc8a46b59aa8a6114a79312b82e/kafka/resource_kafka_acl.go#L132) is never true and the method falls back to the partial match code below. The partial match[¹] considers two acls with just `Principal` and `Operation` equal and in my case it swaps the two ACLs with different `Hosts`.

This PR adds the missing field to the acl from kafka so that two identical ACLs are detected.

[¹] tbh i don't understand why the partial match section exists...