### PR TITLE
Fix example TF file which was failing with a TLS error

### DIFF
--- a/examples/main.tf
+++ b/examples/main.tf
@@ -10,8 +10,8 @@ provider "kafka" {
   bootstrap_servers = ["localhost:9092"]
 
   ca_cert     = file("../secrets/ca.crt")
-  client_cert = file("../secrets/terraform-cert.pem")
-  client_key  = file("../secrets/terraform.pem")
+  client_cert = file("../secrets/client.pem")
+  client_key  = file("../secrets/client-no-password.key")
   tls_enabled = true
 }
 


### PR DESCRIPTION
Example main.tf was failing when trying to send to the docker-compose stack with: 

`Error: kafka: client has run out of available brokers to talk to: remote error: tls: bad certificate`

With this change it work OK.

