### PR TITLE
fix and parallelize acceptance tests

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,4 +1,3 @@
-TEST?=./...
 GOFMT_FILES?=$$(find . -name '*.go' |grep -v vendor)
 default: build
 
@@ -6,7 +5,7 @@ build:
 	go build .
 
 test:
-	 go test $(TEST) -v $(TESTARGS)
+	 go test ./kafka -v $(TESTARGS)
 
 testacc:
 	GODEBUG=x509ignoreCN=0 \
@@ -18,6 +17,6 @@ testacc:
 	KAFKA_SKIP_VERIFY=false \
 	KAFKA_ENABLE_TLS=true \
 	TF_LOG=DEBUG \
-	TF_ACC=1 go test $(TEST) -v $(TESTARGS) -timeout 9m -count=1
+	TF_ACC=1 go test ./kafka -v $(TESTARGS) -timeout 9m -count=1
 
 .PHONY: build test testacc

--- a/kafka/data_source_kafka_topic_test.go
+++ b/kafka/data_source_kafka_topic_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAcc_TopicData(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)

--- a/kafka/lazy_init_test.go
+++ b/kafka/lazy_init_test.go
@@ -8,8 +8,9 @@ import (
 	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
 )
 
-//lintignore:AT001
+// lintignore:AT001
 func TestAcc_LazyInit(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)

--- a/kafka/provider_test.go
+++ b/kafka/provider_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
 )
 
-var testProvider *schema.Provider
+var testProvider, _ = overrideProvider()
 var testBootstrapServers []string = bootstrapServersFromEnv()
 
 func TestProvider(t *testing.T) {
@@ -57,7 +57,6 @@ func overrideProvider() (*schema.Provider, error) {
 		return nil, fmt.Errorf("Could not configure provider")
 	}
 
-	testProvider = provider
 	return provider, nil
 }
 

--- a/kafka/resource_kafka_acl_test.go
+++ b/kafka/resource_kafka_acl_test.go
@@ -13,6 +13,7 @@ import (
 )
 
 func TestAcc_ACLCreateAndUpdate(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)
@@ -65,6 +66,7 @@ func TestAcc_ACLCreateAndUpdate(t *testing.T) {
 }
 
 func TestAcc_ACLDeletedOutsideOfTerraform(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)

--- a/kafka/resource_kafka_quota_test.go
+++ b/kafka/resource_kafka_quota_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestAcc_BasicQuota(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)
@@ -31,6 +32,7 @@ func TestAcc_BasicQuota(t *testing.T) {
 }
 
 func TestAcc_QuotaConfigUpdate(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)
@@ -171,7 +173,7 @@ func testAccCheckQuotaDestroy(s *terraform.State) error {
 	return nil
 }
 
-//lintignore:AT004
+// lintignore:AT004
 func cfgs(t *testing.T, bs string, extraCfg string) string {
 	return fmt.Sprintf(`
 provider "kafka" {

--- a/kafka/resource_kafka_topic_test.go
+++ b/kafka/resource_kafka_topic_test.go
@@ -15,6 +15,7 @@ import (
 )
 
 func TestAcc_BasicTopic(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)
@@ -35,6 +36,7 @@ func TestAcc_BasicTopic(t *testing.T) {
 }
 
 func TestAcc_TopicConfigUpdate(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)
@@ -87,6 +89,7 @@ func testAccCheckTopicDestroy(s *terraform.State) error {
 }
 
 func TestAcc_TopicUpdatePartitions(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)
@@ -112,6 +115,7 @@ func TestAcc_TopicUpdatePartitions(t *testing.T) {
 }
 
 func TestAcc_TopicAlterReplicationFactor(t *testing.T) {
+	t.Parallel()
 	u, err := uuid.GenerateUUID()
 	if err != nil {
 		t.Fatal(err)
@@ -238,15 +242,6 @@ func testResourceTopic_initialCheck(s *terraform.State) error {
 func testResourceTopic_produceMessages(messages []*sarama.ProducerMessage) r.TestCheckFunc {
 	return func(s *terraform.State) error {
 		c := testProvider.Meta().(*LazyClient)
-		if c == nil {
-			return fmt.Errorf("unable to get lazy client")
-		}
-		if c.inner == nil {
-			err := c.init()
-			if err != nil {
-				return fmt.Errorf("unable to get original kafka client")
-			}
-		}
 
 		config := c.inner.config
 		kafkaConfig, err := config.newKafkaConfig()


### PR DESCRIPTION
Happy holidays!

This PR greatly speeds up testing by running tests in parallel. Before the change `make testacc` was always timing out as it would've taken 12 minutes to complete all tests serially. This is due to the tests needing to run many Terraform commands, which are very slow. These tests are safe to run in parallel as they are using UUIDs for resource names. After the change it takes less than 3 minutes to run them (tested on M1 max machine).

```
> make testacc
.
.
.
--- PASS: TestAcc_TopicAlterReplicationFactor (145.34s)
PASS
ok      github.com/Mongey/terraform-provider-kafka/kafka        147.024s
```

A couple of other changes were also included:
- Fix failing tests due to nil dereference on [this line](https://github.com/Mongey/terraform-provider-kafka/blob/6218bcac5c374e47de16800d7cdde8a895b26c53/kafka/provider_test.go#L25) 
- Update the makefile to explicitly reference `./kafka` directory (there are no tests in other directories) so you can see streaming output from tests instead of the weird effect of seeing the screen "freeze" until all the tests complete with `go test ./...`.
