### PR TITLE
add SCRAM user credential resource

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,36 @@ resource "kafka_quota" "test" {
 | `entity_type`        | The entity type (client-id, user, ip)          |
 | `config`             | A map of string attributes for the entity      |
 
+### `kafka_user_scram_credential`
+A resource for managing Kafka SCRAM user credentials.
+
+#### Example
+
+```hcl
+provider "kafka" {
+  bootstrap_servers = ["localhost:9092"]
+  ca_cert           = file("../secrets/ca.crt")
+  client_cert       = file("../secrets/terraform-cert.pem")
+  client_key        = file("../secrets/terraform.pem")
+}
+
+resource "kafka_user_scram_credential" "test" {
+  username               = "user1"
+  scram_mechanism        = "SCRAM-SHA-256"
+  scram_iterations       = "8192"
+  password               = "password"
+}
+```
+
+#### Properties
+
+| Property             | Description                                    |
+| -------------------- | ---------------------------------------------- |
+| `username`        | The username                         |
+| `scram_mechanism`        | The SCRAM mechanism (SCRAM-SHA-256 or SCRAM-SHA-512)          |
+| `scram_iterations`             | The number of SCRAM iterations (must be >= 4096). Default: 4096       |
+| `password` | The password for the user |
+
 ## Requirements
 * [>= Kafka 1.0.0][3]
 

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -28,7 +28,7 @@ type Config struct {
 
 func (c *Config) newKafkaConfig() (*sarama.Config, error) {
 	kafkaConfig := sarama.NewConfig()
-	kafkaConfig.Version = sarama.V2_6_0_0
+	kafkaConfig.Version = sarama.V2_7_0_0
 	kafkaConfig.ClientID = "terraform-provider-kafka"
 	kafkaConfig.Admin.Timeout = time.Duration(c.Timeout) * time.Second
 	kafkaConfig.Metadata.Full = true // the default, but just being clear

--- a/kafka/kafka_user_scram_credentials.go
+++ b/kafka/kafka_user_scram_credentials.go
@@ -1,0 +1,147 @@
+package kafka
+
+import (
+	"crypto/rand"
+	"fmt"
+	"log"
+	"strings"
+
+	"github.com/Shopify/sarama"
+)
+
+type UserScramCredential struct {
+	Name       string
+	Mechanism  sarama.ScramMechanismType
+	Iterations int32
+	Password   []byte
+}
+
+func (usc UserScramCredential) String() string {
+	return strings.Join([]string{usc.Name, usc.Mechanism.String(), fmt.Sprint(usc.Iterations)}, "|")
+}
+
+func (usc UserScramCredential) ID() string {
+	return strings.Join([]string{usc.Name, usc.Mechanism.String()}, "|")
+}
+
+type UserScramCredentialMissingError struct {
+	msg string
+}
+
+func (e UserScramCredentialMissingError) Error() string { return e.msg }
+
+const (
+	saltSize = 64
+)
+
+func (c *Client) UpsertUserScramCredential(userScramCredential UserScramCredential) error {
+	log.Printf("[INFO] Upserting user scram credential %v", userScramCredential)
+	admin, err := sarama.NewClusterAdminFromClient(c.client)
+	if err != nil {
+		return err
+	}
+
+	upsert, err := prepareUpsert(userScramCredential)
+	if err != nil {
+		return err
+	}
+
+	results, err := admin.UpsertUserScramCredentials([]sarama.AlterUserScramCredentialsUpsert{upsert})
+	if err != nil {
+		return err
+	}
+
+	for _, res := range results {
+		if res.ErrorCode != sarama.ErrNoError {
+			return res.ErrorCode
+		}
+	}
+
+	return nil
+}
+
+func (c *Client) DescribeUserScramCredential(username string, mechanism string) (*UserScramCredential, error) {
+	log.Printf("[INFO] Describing user scram credential %s", username)
+	admin, err := sarama.NewClusterAdminFromClient(c.client)
+	if err != nil {
+		return nil, err
+	}
+
+	results, err := admin.DescribeUserScramCredentials([]string{username})
+	if err != nil {
+		return nil, err
+	}
+
+	num := len(results)
+	if num != 1 {
+		return nil, fmt.Errorf("Got %d results (expected 1) when describing user scram credential %s", num, username)
+	}
+
+	res := results[0]
+	if res.ErrorCode == 91 { // RESOURCE_NOT_FOUND
+		msg := fmt.Sprintf("User scram credential %s could not be found", username)
+		return nil, UserScramCredentialMissingError{msg: msg}
+	}
+	if res.ErrorCode != sarama.ErrNoError {
+		return nil, fmt.Errorf("Error describing user scram credential %s: %s", username, res.ErrorCode)
+	}
+	for _, info := range res.CredentialInfos {
+		if info.Mechanism.String() == mechanism {
+			r := UserScramCredential{
+				Name:       username,
+				Mechanism:  info.Mechanism,
+				Iterations: info.Iterations,
+			}
+			return &r, nil
+		}
+	}
+
+	msg := fmt.Sprintf("User scram credential %s with mechanism %s could not be found", username, mechanism)
+	return nil, UserScramCredentialMissingError{msg: msg}
+}
+
+func (c *Client) DeleteUserScramCredential(userScramCredential UserScramCredential) error {
+	log.Printf("[INFO] Deleting user scram credential %v", userScramCredential)
+	admin, err := sarama.NewClusterAdminFromClient(c.client)
+	if err != nil {
+		return err
+	}
+
+	delete := prepareDelete(userScramCredential)
+	results, err := admin.DeleteUserScramCredentials([]sarama.AlterUserScramCredentialsDelete{delete})
+	if err != nil {
+		return err
+	}
+
+	for _, res := range results {
+		if res.ErrorCode != sarama.ErrNoError {
+			return res.ErrorCode
+		}
+	}
+
+	return nil
+}
+
+func prepareUpsert(userScramCredential UserScramCredential) (sarama.AlterUserScramCredentialsUpsert, error) {
+	var ret sarama.AlterUserScramCredentialsUpsert
+	ret.Name = userScramCredential.Name
+	ret.Mechanism = userScramCredential.Mechanism
+	ret.Iterations = userScramCredential.Iterations
+	ret.Password = userScramCredential.Password
+	salt, err := generateRandomBytes(saltSize)
+	ret.Salt = append(ret.Salt, salt...)
+	return ret, err
+}
+
+func generateRandomBytes(n int) ([]byte, error) {
+	b := make([]byte, n)
+	_, err := rand.Read(b)
+	return b, err
+}
+
+func prepareDelete(userScramCredential UserScramCredential) sarama.AlterUserScramCredentialsDelete {
+	var ret sarama.AlterUserScramCredentialsDelete
+	ret.Name = userScramCredential.Name
+	ret.Mechanism = userScramCredential.Mechanism
+	return ret
+}

--- a/kafka/lazy_client.go
+++ b/kafka/lazy_client.go
@@ -161,3 +161,27 @@ func (c *LazyClient) DescribeQuota(entityType string, entityName string) (*Quota
 	}
 	return c.inner.DescribeQuota(entityType, entityName)
 }
+
+func (c *LazyClient) UpsertUserScramCredential(userScramCredential UserScramCredential) error {
+	err := c.init()
+	if err != nil {
+		return err
+	}
+	return c.inner.UpsertUserScramCredential(userScramCredential)
+}
+
+func (c *LazyClient) DescribeUserScramCredential(username string, mechanism string) (*UserScramCredential, error) {
+	err := c.init()
+	if err != nil {
+		return nil, err
+	}
+	return c.inner.DescribeUserScramCredential(username, mechanism)
+}
+
+func (c *LazyClient) DeleteUserScramCredential(userScramCredential UserScramCredential) error {
+	err := c.init()
+	if err != nil {
+		return err
+	}
+	return c.inner.DeleteUserScramCredential(userScramCredential)
+}

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -101,9 +101,10 @@ func Provider() *schema.Provider {
 
 		ConfigureFunc: providerConfigure,
 		ResourcesMap: map[string]*schema.Resource{
-			"kafka_topic": kafkaTopicResource(),
-			"kafka_acl":   kafkaACLResource(),
-			"kafka_quota": kafkaQuotaResource(),
+			"kafka_topic":                 kafkaTopicResource(),
+			"kafka_acl":                   kafkaACLResource(),
+			"kafka_quota":                 kafkaQuotaResource(),
+			"kafka_user_scram_credential": kafkaUserScramCredentialResource(),
 		},
 		DataSourcesMap: map[string]*schema.Resource{
 			"kafka_topic": kafkaTopicDataSource(),

--- a/kafka/resource_kafka_user_scram_credential.go
+++ b/kafka/resource_kafka_user_scram_credential.go
@@ -1,0 +1,151 @@
+package kafka
+
+import (
+	"context"
+	"log"
+
+	"github.com/Shopify/sarama"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
+)
+
+const defaultIterations int32 = 4096
+
+func kafkaUserScramCredentialResource() *schema.Resource {
+	//lintignore:R011
+	return &schema.Resource{
+		CreateContext: userScramCredentialCreate,
+		ReadContext:   userScramCredentialRead,
+		UpdateContext: userScramCredentialUpdate,
+		DeleteContext: userScramCredentialDelete,
+		Schema: map[string]*schema.Schema{
+			"username": {
+				Type:        schema.TypeString,
+				Required:    true,
+				ForceNew:    true,
+				Description: "The name of the credential",
+			},
+			"scram_mechanism": {
+				Type:             schema.TypeString,
+				Required:         true,
+				ForceNew:         true,
+				ValidateDiagFunc: validateDiagFunc(validation.StringInSlice([]string{sarama.SASLTypeSCRAMSHA256, sarama.SASLTypeSCRAMSHA512}, false)),
+				Description:      "The SCRAM mechanism used to generate the credential (SCRAM-SHA-256, SCRAM-SHA-512)",
+			},
+			"scram_iterations": {
+				Type:         schema.TypeInt,
+				Optional:     true,
+				ForceNew:     false,
+				Default:      defaultIterations,
+				ValidateFunc: validation.IntAtLeast(4096),
+				Description:  "The number of SCRAM iterations used when generating the credential",
+			},
+			"password": {
+				Type:         schema.TypeString,
+				Required:     true,
+				ForceNew:     false,
+				ValidateFunc: validation.StringIsNotWhiteSpace,
+				Description:  "The password of the credential",
+				Sensitive:    true,
+			},
+		},
+	}
+}
+
+func userScramCredentialCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Creating user scram credential")
+	c := meta.(*LazyClient)
+	userScramCredential := parseUserScramCredential(d)
+
+	err := c.UpsertUserScramCredential(userScramCredential)
+	if err != nil {
+		log.Println("[ERROR] Failed to create user scram credential")
+		return diag.FromErr(err)
+	}
+
+	d.SetId(userScramCredential.ID())
+	return nil
+}
+
+func userScramCredentialRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Println("[INFO] Reading user scram credential")
+	c := meta.(*LazyClient)
+	username := d.Get("username").(string)
+	mechanism := d.Get("scram_mechanism").(string)
+
+	userScramCredential, err := c.DescribeUserScramCredential(username, mechanism)
+	if err != nil {
+		log.Printf("[ERROR] Error getting user scram credential %s from Kafka", err)
+		_, ok := err.(UserScramCredentialMissingError)
+		if ok {
+			d.SetId("")
+			return nil
+		}
+
+		return diag.FromErr(err)
+	}
+
+	log.Printf("[DEBUG] Setting the state from Kafka %v", userScramCredential)
+
+	errSet := errSetter{d: d}
+	errSet.Set("username", userScramCredential.Name)
+	errSet.Set("scram_mechanism", userScramCredential.Mechanism.String())
+	errSet.Set("scram_iterations", userScramCredential.Iterations)
+
+	if errSet.err != nil {
+		return diag.FromErr(errSet.err)
+	}
+
+	return nil
+}
+
+func userScramCredentialUpdate(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Updating user scram credential")
+	c := meta.(*LazyClient)
+	userScramCredential := parseUserScramCredential(d)
+
+	err := c.UpsertUserScramCredential(userScramCredential)
+	if err != nil {
+		log.Println("[ERROR] Failed to update user scram credential")
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func userScramCredentialDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
+	log.Printf("[INFO] Deleting user scram credential")
+	c := meta.(*LazyClient)
+	userScramCredential := parseUserScramCredential(d)
+
+	err := c.DeleteUserScramCredential(userScramCredential)
+	if err != nil {
+		log.Println("[ERROR] Failed to delete user scram credential")
+		return diag.FromErr(err)
+	}
+
+	return nil
+}
+
+func parseUserScramCredential(d *schema.ResourceData) UserScramCredential {
+	scram_mechanism_string := d.Get("scram_mechanism").(string)
+	mechanism := convertedScramMechanism(scram_mechanism_string)
+	return UserScramCredential{
+		Name:       d.Get("username").(string),
+		Mechanism:  mechanism,
+		Iterations: int32(d.Get("scram_iterations").(int)),
+		Password:   []byte(d.Get("password").(string)),
+	}
+}
+
+func convertedScramMechanism(scram_mechanism_string string) sarama.ScramMechanismType {
+	switch scram_mechanism_string {
+	case sarama.SCRAM_MECHANISM_SHA_256.String():
+		return sarama.SCRAM_MECHANISM_SHA_256
+	case sarama.SCRAM_MECHANISM_SHA_512.String():
+		return sarama.SCRAM_MECHANISM_SHA_512
+	default:
+		return sarama.SCRAM_MECHANISM_UNKNOWN
+	}
+}

--- a/kafka/resource_kafka_user_scram_credential_test.go
+++ b/kafka/resource_kafka_user_scram_credential_test.go
@@ -1,0 +1,210 @@
+package kafka
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+	"testing"
+
+	uuid "github.com/hashicorp/go-uuid"
+	r "github.com/hashicorp/terraform-plugin-sdk/v2/helper/resource"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/terraform"
+)
+
+func TestAcc_UserScramCredentialBasic(t *testing.T) {
+	t.Parallel()
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	username := fmt.Sprintf("test-%s", u)
+	bs := testBootstrapServers[0]
+
+	r.Test(t, r.TestCase{
+		ProviderFactories: overrideProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckUserScramCredentialDestroy,
+		Steps: []r.TestStep{
+			{
+				Config: cfgs(t, bs, fmt.Sprintf(testResourceUserScramCredential_SHA256, username)),
+				Check:  testResourceUserScramCredentialCheck_withoutIterations,
+			},
+		},
+	})
+}
+
+func TestAcc_UserScramCredentialWithIterations(t *testing.T) {
+	t.Parallel()
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	username := fmt.Sprintf("test-%s", u)
+	bs := testBootstrapServers[0]
+
+	r.Test(t, r.TestCase{
+		ProviderFactories: overrideProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckUserScramCredentialDestroy,
+		Steps: []r.TestStep{
+			{
+				Config: cfg(t, bs, fmt.Sprintf(testResourceUserScramCredential_WithIterations, username, 8192)),
+				Check:  testResourceUserScramCredentialCheck_withIterations,
+			},
+		},
+	})
+}
+
+func TestAcc_UserScramCredentialSHA512(t *testing.T) {
+	t.Parallel()
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	username := fmt.Sprintf("test-%s", u)
+	bs := testBootstrapServers[0]
+
+	r.Test(t, r.TestCase{
+		ProviderFactories: overrideProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckUserScramCredentialDestroy,
+		Steps: []r.TestStep{
+			{
+				Config: cfg(t, bs, fmt.Sprintf(testResourceUserScramCredential_SHA512, username)),
+				Check:  testResourceUserScramCredentialCheck_withoutIterations,
+			},
+		},
+	})
+}
+
+func TestAcc_UserScramCredentialConfigUpdate(t *testing.T) {
+	t.Parallel()
+	u, err := uuid.GenerateUUID()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	username := fmt.Sprintf("test-%s", u)
+	bs := testBootstrapServers[0]
+
+	r.Test(t, r.TestCase{
+		ProviderFactories: overrideProviderFactory(),
+		PreCheck:          func() { testAccPreCheck(t) },
+		CheckDestroy:      testAccCheckUserScramCredentialDestroy,
+		Steps: []r.TestStep{
+			{
+				Config: cfg(t, bs, fmt.Sprintf(testResourceUserScramCredential_WithIterations, username, 4096)),
+				Check:  testResourceUserScramCredentialCheck_withIterations,
+			},
+			{
+				Config: cfg(t, bs, fmt.Sprintf(testResourceUserScramCredential_WithIterations, username, 8192)),
+				Check:  testResourceUserScramCredentialCheck_withIterations,
+			},
+		},
+	})
+}
+
+func testResourceUserScramCredentialCheck_withoutIterations(s *terraform.State) error {
+	return testResourceUserScramCredentialCheck(s, false)
+}
+
+func testResourceUserScramCredentialCheck_withIterations(s *terraform.State) error {
+	return testResourceUserScramCredentialCheck(s, true)
+}
+
+func testResourceUserScramCredentialCheck(s *terraform.State, withIterations bool) error {
+	resourceState := s.Modules[0].Resources["kafka_user_scram_credential.test"]
+	if resourceState == nil {
+		return fmt.Errorf("resource not found in state")
+	}
+
+	instanceState := resourceState.Primary
+	if instanceState == nil {
+		return fmt.Errorf("resource has no primary instance")
+	}
+
+	username := instanceState.Attributes["username"]
+	scramMechanism := instanceState.Attributes["scram_mechanism"]
+	expectedIterations := defaultIterations
+	if withIterations {
+		i, err := strconv.Atoi(instanceState.Attributes["scram_iterations"])
+		if err != nil {
+			return err
+		}
+		expectedIterations = int32(i)
+	}
+
+	client := testProvider.Meta().(*LazyClient)
+	userScramCredential, err := client.DescribeUserScramCredential(username, scramMechanism)
+	if err != nil {
+		return err
+	}
+
+	id := instanceState.ID
+	expectedId := strings.Join([]string{username, scramMechanism}, "|")
+
+	if id != expectedId {
+		return fmt.Errorf("id '%s' does not match expected id '%s'", id, expectedId)
+	}
+
+	if userScramCredential.Iterations != expectedIterations {
+		return fmt.Errorf("scram iterations should be %d but got '%d'", expectedIterations, userScramCredential.Iterations)
+	}
+
+	return nil
+}
+
+func testAccCheckUserScramCredentialDestroy(s *terraform.State) error {
+	resourceState := s.Modules[0].Resources["kafka_user_scram_credential.test"]
+	if resourceState == nil {
+		return fmt.Errorf("resource not found in state")
+	}
+
+	instanceState := resourceState.Primary
+	if instanceState == nil {
+		return fmt.Errorf("resource has no primary instance")
+	}
+
+	username := instanceState.Attributes["username"]
+	mechanism := instanceState.Attributes["scram_mechanism"]
+
+	client := testProvider.Meta().(*LazyClient)
+	_, err := client.DescribeUserScramCredential(username, mechanism)
+
+	if _, ok := err.(UserScramCredentialMissingError); !ok {
+		if err == nil {
+			return fmt.Errorf("user scram credential was not destroyed")
+		} else {
+			return fmt.Errorf("user scram credential was not destroyed %v", err.Error())
+		}
+	}
+
+	return nil
+}
+
+const testResourceUserScramCredential_SHA256 = `
+resource "kafka_user_scram_credential" "test" {
+  username               = "%s"
+  scram_mechanism        = "SCRAM-SHA-256"
+  password               = "test"
+}
+`
+
+const testResourceUserScramCredential_SHA512 = `
+resource "kafka_user_scram_credential" "test" {
+  username               = "%s"
+  scram_mechanism        = "SCRAM-SHA-512"
+  password               = "test"
+}
+`
+const testResourceUserScramCredential_WithIterations = `
+resource "kafka_user_scram_credential" "test" {
+  username               = "%s"
+  scram_mechanism        = "SCRAM-SHA-256"
+  scram_iterations       = "%d"
+  password               = "test"
+}
+`


### PR DESCRIPTION
Issue https://github.com/Mongey/terraform-provider-kafka/issues/64

Used the changes in this closed PR as a starting point https://github.com/Mongey/terraform-provider-kafka/pull/207 

Worth noting that the ID for a credential is (username, SCRAM mechanism) as a single username can be associated with multiple credentials.

```
> kafka-configs.sh --bootstrap-server localhost:9092 --command-config kafka.properties --describe --entity-type users
SCRAM credential configs for user-principal 'donovan' are SCRAM-SHA-256=iterations=4096, SCRAM-SHA-512=iterations=4096
```