### PR TITLE
feat(config): Use a proxy dialer

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/IBM/sarama"
+	"golang.org/x/net/proxy"
 )
 
 type Config struct {
@@ -33,6 +34,9 @@ func (c *Config) newKafkaConfig() (*sarama.Config, error) {
 	kafkaConfig.Admin.Timeout = time.Duration(c.Timeout) * time.Second
 	kafkaConfig.Metadata.Full = true // the default, but just being clear
 	kafkaConfig.Metadata.AllowAutoTopicCreation = false
+
+	kafkaConfig.Net.Proxy.Enable = true
+	kafkaConfig.Net.Proxy.Dialer = proxy.FromEnvironment()
 
 	if c.saslEnabled() {
 		switch c.SASLMechanism {


### PR DESCRIPTION
This PR creates a  Go `net/proxy` `Dialer` with the [`FromEnvironment`](https://pkg.go.dev/golang.org/x/net/proxy#FromEnvironment) method and passes it in the Kafka client configuration under `Net.Proxy`. This allows users to configure a proxy client from environment variables (for example using `ALL_PROXY`). If no environment variable is set, the proxy will be transparent, making this PR backwards-compatible.

For more safety, we could place this code under a condition on an extra configuration key (`use_proxy`, or specify explicitly the proxy configuration in the provider configuration). However, I've inspired this from [the PostgreSQL provider's proxy support](https://github.com/cyrilgdn/terraform-provider-postgresql/blob/master/website/docs/index.html.markdown#socks5-proxy-support)

I've tested this manually on one of our projects that uses this provider. Specifying a `ALL_PROXY=localhost:1080` environment variable makes the provider pas through the local proxy. Unsetting the variable makes it behave as before.

Fixes https://github.com/Mongey/terraform-provider-kafka/issues/147