### PR TITLE
fix: wait for quota state after creation

### DIFF
--- a/kafka/resource_kafka_quota.go
+++ b/kafka/resource_kafka_quota.go
@@ -2,9 +2,12 @@ package kafka
 
 import (
 	"context"
+	"fmt"
 	"log"
+	"time"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
+	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/retry"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/validation"
 )
@@ -51,10 +54,36 @@ func quotaCreate(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 		return diag.FromErr(err)
 	}
 
+	stateConf := &retry.StateChangeConf{
+		Pending:      []string{"Pending"},
+		Target:       []string{"Created"},
+		Refresh:      quotaCreatedFunc(c, quota),
+		Timeout:      time.Duration(c.Config.Timeout) * time.Second,
+		Delay:        1 * time.Second,
+		PollInterval: 2 * time.Second,
+	}
+
+	if _, err := stateConf.WaitForStateContext(ctx); err != nil {
+		return diag.FromErr(fmt.Errorf("error waiting for quota (%s) to be created: %s", quota.ID(), err))
+	}
+
 	d.SetId(quota.ID())
-	quotaRead(ctx, d, meta)
 
 	return nil
+}
+
+func quotaCreatedFunc(client *LazyClient, q Quota) retry.StateRefreshFunc {
+	return func() (result interface{}, s string, err error) {
+		fq, err := client.DescribeQuota(q.EntityType, q.EntityName)
+		switch e := err.(type) {
+		case QuotaMissingError:
+			return fq, "Pending", nil
+		case nil:
+			return fq, "Created", nil
+		default:
+			return fq, "Error", e
+		}
+	}
 }
 
 func quotaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
@@ -74,7 +103,7 @@ func quotaDelete(ctx context.Context, d *schema.ResourceData, meta interface{}) 
 func quotaRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag.Diagnostics {
 	log.Println("[INFO] Reading Quota")
 	c := meta.(*LazyClient)
-	
+
 	entityType := d.Get("entity_type").(string)
 	entityName := d.Get("entity_name").(string)
 	log.Printf("[INFO] Reading Quota %s", entityName)


### PR DESCRIPTION
We are using this provider to maintain kafka resources, including quotas.  
When creating and updating quotas is fails in 90% of cases because the provider creates it in kafka, and then immediately queries for it, but it doesn't find it at this point, as it seems it takes a little bit of time to appear in Kafka.

Here are the logs we were getting for such a scenario:
```
[INFO] Alter quota: timestamp="2024-02-19T12:46:14.578+0200"
[TRACE] Alter Quota Request &{0 [{[{user 0 User:CN=dev-enablement/test-tf-apply}] [{request_percentage 100 false} {consumer_byte_rate 5.24288e+06 false} {producer_byte_rate 5.24288e+06 false}]}] false}: timestamp="2024-02-19T12:46:14.578+0200"
[TRACE] ThrottleTime: 0: timestamp="2024-02-19T12:46:15.178+0200"
[INFO] Reading Quota: timestamp="2024-02-19T12:46:15.179+0200"
[INFO] Reading Quota User:CN=dev-enablement/test-tf-apply: timestamp="2024-02-19T12:46:15.179+0200"
[INFO] Describing Quota: timestamp="2024-02-19T12:46:15.179+0200"
[TRACE] Describe Quota Request &{0 [{user 0 User:CN=dev-enablement/test-tf-apply}] true}: timestamp="2024-02-19T12:46:15.179+0200"
[TRACE] ThrottleTime: 0: timestamp="2024-02-19T12:46:15.242+0200"
[ERROR] Error getting quota User:CN=dev-enablement/test-tf-apply could not be found from Kafka: timestamp="2024-02-19T12:46:15.242+0200"
```

With this fix, we'll be waiting until the quota is created in Kafka (just like for topics).
I tested this locally and it fixes the issue.