### PR TITLE
Add SourceDynamicDefaultBroker as a type to refuse to retrieve topic settings

### DIFF
--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -60,7 +60,9 @@ func isDefault(tc *sarama.ConfigEntry, version int) bool {
 	if version == 0 {
 		return tc.Default
 	}
-	return tc.Source == sarama.SourceDefault || tc.Source == sarama.SourceStaticBroker
+	return tc.Source == sarama.SourceDefault ||
+		tc.Source == sarama.SourceStaticBroker ||
+		tc.Source == sarama.SourceDynamicDefaultBroker
 }
 
 func metaToTopic(d *schema.ResourceData, meta interface{}) Topic {


### PR DESCRIPTION
Fix unexpected diff when kafka broker has cluster-wide config.

This patch for #407. 