### PR TITLE
fix(fail_on): Added fail_on list to enable failing plan on condition such as decreasing partition count

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -35,6 +35,7 @@ type Config struct {
 	SASLAWSProfile          string
 	SASLAWSCredsDebug       bool
 	SASLTokenUrl            string
+	FailOn                  []string
 }
 
 type OAuth2Config interface {
@@ -301,6 +302,7 @@ func (config *Config) copyWithMaskedSensitiveValues() Config {
 		config.SASLAWSRoleArn,
 		config.SASLAWSCredsDebug,
 		config.SASLTokenUrl,
+		config.FailOn,
 	}
 	return copy
 }

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -134,9 +134,9 @@ func Provider() *schema.Provider {
 				Description: "Timeout in seconds",
 			},
 			"fail_on": {
-				Type:        schema.TypeList,
-				Elem:        &schema.Schema{Type: schema.TypeString},
-				Optional:    true,
+				Type:     schema.TypeList,
+				Elem:     &schema.Schema{Type: schema.TypeString},
+				Optional: true,
 				DefaultFunc: func() (interface{}, error) {
 					return []interface{}{}, nil
 				},

--- a/kafka/utils.go
+++ b/kafka/utils.go
@@ -72,3 +72,13 @@ func validateDiagFunc(validateFunc func(interface{}, string) ([]string, []error)
 		return diags
 	}
 }
+
+// Contains checks if a slice contains a specific item, ignoring case.
+func Contains(slice []string, item string) bool {
+	for _, s := range slice {
+		if strings.EqualFold(s, item) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
When using the provider, we found we wanted to fail plans if the partition count was reduced rather than trigger ForceNew.
To support this but let others choose to replace the resource, we added `fail_on`, a list of string conditions. The code can check for these to override behaviors, which you can pass in when starting the provider to feature flag this change. 