### PR TITLE
fix(topic.go): enhance MSK Serverless compatibility

### DIFF
--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -47,11 +47,13 @@ func ReplicaCount(c sarama.Client, topic string, partitions []int32) (int, error
 }
 
 func configToResources(topic Topic) []*sarama.AlterConfigsResource {
+	ConfigMSKServerless := topic.Config
+	delete(ConfigMSKServerless, "cleanup.policy")
 	return []*sarama.AlterConfigsResource{
 		{
 			Type:          sarama.TopicResource,
 			Name:          topic.Name,
-			ConfigEntries: topic.Config,
+			ConfigEntries: ConfigMSKServerless,
 		},
 	}
 }


### PR DESCRIPTION
by omitting cleanup.policy which can't be changed in MSK Serverless

- reference: https://docs.aws.amazon.com/msk/latest/developerguide/serverless-config.html

TODO
- [ ] add a way to detect MSKServerless, because we shouldn't remove `cleanup.policy` for non-MSKServerless