### PR TITLE
Add support for DelegationToken

### DIFF
--- a/kafka/kafka_acls.go
+++ b/kafka/kafka_acls.go
@@ -264,38 +264,16 @@ func (c *Client) CreateACL(s StringlyTypedACL) error {
 	return nil
 }
 
-func stringToACLResource(in string) sarama.AclResourceType {
-	switch in {
-	case "Unknown":
-		return sarama.AclResourceUnknown
-	case "Any":
-		return sarama.AclResourceAny
-	case "Topic":
-		return sarama.AclResourceTopic
-	case "Group":
-		return sarama.AclResourceGroup
-	case "Cluster":
-		return sarama.AclResourceCluster
-	case "TransactionalID":
-		return sarama.AclResourceTransactionalID
+func stringToACLResource(in string) (out sarama.AclResourceType) {
+	if err := out.UnmarshalText([]byte(in)); err == nil {
+		return
 	}
 	return unknownConversion
 }
 
 func ACLResourceToString(in sarama.AclResourceType) string {
-	switch in {
-	case sarama.AclResourceUnknown:
-		return "Unknown"
-	case sarama.AclResourceAny:
-		return "Any"
-	case sarama.AclResourceTopic:
-		return "Topic"
-	case sarama.AclResourceGroup:
-		return "Group"
-	case sarama.AclResourceCluster:
-		return "Cluster"
-	case sarama.AclResourceTransactionalID:
-		return "TransactionalID"
+	if out, err := in.MarshalText(); err == nil {
+		return string(out)
 	}
 	return "unknownConversion"
 }


### PR DESCRIPTION
This PR solves #478. 
I am following a different approach to convert types using sarama functions instead of custom ones. I see this more maintainable and new ACLs types included in the library will be included automatically in providers, but this is open to discussion. If you like this way maybe it is interesting to refactor the code in this file to follow the same strategy.