### PR TITLE
Add sasl_aws_external_id as an additional provider parameter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.23.4
 
 require (
 	github.com/IBM/sarama v1.45.2-0.20250319225116-d6ca80a198c4
-	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.1
+	github.com/aws/aws-msk-iam-sasl-signer-go v1.0.2
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.62
 	github.com/hashicorp/go-cty v1.5.0
 	github.com/hashicorp/go-uuid v1.0.3

--- a/go.sum
+++ b/go.sum
@@ -23,8 +23,8 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-msk-iam-sasl-signer-go v1.0.1 h1:nMp7diZObd4XEVUR0pEvn7/E13JIgManMX79Q6quV6E=
-github.com/aws/aws-msk-iam-sasl-signer-go v1.0.1/go.mod h1:MVYeeOhILFFemC/XlYTClvBjYZrg/EPd3ts885KrNTI=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.2 h1:w/EizRUXP2Iq/ni4ph02JtD+IYCBAiHo7lYf31q2s5o=
+github.com/aws/aws-msk-iam-sasl-signer-go v1.0.2/go.mod h1:MVYeeOhILFFemC/XlYTClvBjYZrg/EPd3ts885KrNTI=
 github.com/aws/aws-sdk-go-v2 v1.36.3 h1:mJoei2CxPutQVxaATCzDUjcZEjVRdpsiiXi2o38yqWM=
 github.com/aws/aws-sdk-go-v2 v1.36.3/go.mod h1:LLXuLpgzEbD766Z5ECcRmi8AzSwfZItDtmABVkRLGzg=
 github.com/aws/aws-sdk-go-v2/config v1.28.2 h1:FLvWA97elBiSPdIol4CXfIAY1wlq3KzoSgkMuZSuSe8=

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -36,6 +36,7 @@ type Config struct {
 	SASLAWSContainerCredentialsFullUri     string
 	SASLAWSRegion                          string
 	SASLAWSRoleArn                         string
+	SASLAWSExternalId                      string
 	SASLAWSProfile                         string
 	SASLAWSAccessKey                       string
 	SASLAWSSecretKey                       string
@@ -103,7 +104,7 @@ func (c *Config) Token() (*sarama.AccessToken, error) {
 		token, _, err = signer.GenerateAuthTokenFromCredentialsProvider(context.TODO(), c.SASLAWSRegion, credProvider)
 	} else if c.SASLAWSRoleArn != "" {
 		log.Printf("[INFO] Generating auth token with a role '%s' in '%s'", c.SASLAWSRoleArn, c.SASLAWSRegion)
-		token, _, err = signer.GenerateAuthTokenFromRole(context.TODO(), c.SASLAWSRegion, c.SASLAWSRoleArn, "terraform-kafka-provider")
+		token, _, err = signer.GenerateAuthTokenFromRoleWithExternalId(context.TODO(), c.SASLAWSRegion, c.SASLAWSRoleArn, "terraform-kafka-provider", c.SASLAWSExternalId)
 	} else if c.SASLAWSProfile != "" {
 		log.Printf("[INFO] Generating auth token using profile '%s' in '%s'", c.SASLAWSProfile, c.SASLAWSRegion)
 		token, _, err = signer.GenerateAuthTokenFromProfile(context.TODO(), c.SASLAWSRegion, c.SASLAWSProfile)
@@ -323,6 +324,7 @@ func (config *Config) copyWithMaskedSensitiveValues() Config {
 		config.SASLAWSContainerCredentialsFullUri,
 		config.SASLAWSRegion,
 		config.SASLAWSRoleArn,
+		"*****",
 		config.SASLAWSProfile,
 		config.SASLAWSAccessKey,
 		"*****",

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -91,6 +91,12 @@ func Provider() *schema.Provider {
 				DefaultFunc: schema.EnvDefaultFunc("AWS_ROLE_ARN", nil),
 				Description: "Arn of an AWS IAM role to assume",
 			},
+			"sasl_aws_external_id": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Default:     "",
+				Description: "External ID of the AWS IAM role to assume",
+			},
 			"sasl_aws_profile": {
 				Type:        schema.TypeString,
 				Optional:    true,
@@ -205,6 +211,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SASLPassword:                           d.Get("sasl_password").(string),
 		SASLTokenUrl:                           d.Get("sasl_token_url").(string),
 		SASLAWSRoleArn:                         d.Get("sasl_aws_role_arn").(string),
+		SASLAWSExternalId:                      d.Get("sasl_aws_external_id").(string),
 		SASLAWSProfile:                         d.Get("sasl_aws_profile").(string),
 		SASLAWSAccessKey:                       d.Get("sasl_aws_access_key").(string),
 		SASLAWSSecretKey:                       d.Get("sasl_aws_secret_key").(string),


### PR DESCRIPTION
This is required to assume AWS Roles that have External IDs.

Fixes #541 

This required a PR in the signer library https://github.com/aws/aws-msk-iam-sasl-signer-go/pull/25 and a subsequent release: https://github.com/aws/aws-msk-iam-sasl-signer-go/releases/tag/v1.0.2

Tested with atlantis:

```
╷
│ Warning: Provider development overrides are in effect
│ 
│ The following provider development overrides are set in the CLI
│ configuration:
│  - mongey/kafka in /tmp/dgamba/provider
│ 
│ The behavior may therefore not match any released version of the provider
│ and applying changes may cause the state to become incompatible with
│ published releases.
╵
kafka_topic.this["test-topic-3"]: Creating...
kafka_topic.this["test-topic-1"]: Creating...
kafka_topic.this["test-topic-2"]: Creating...
kafka_topic.this["test-topic-3"]: Creation complete after 4s [id=test-topic-3]
kafka_topic.this["test-topic-1"]: Creation complete after 4s [id=test-topic-1]
kafka_topic.this["test-topic-2"]: Creation complete after 4s [id=test-topic-2]

Apply complete! Resources: 3 added, 0 changed, 0 destroyed.
```