### PR TITLE
Fix msk serverless compatibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.21
+FROM golang:1.23
 
 WORKDIR /go/src/github.com/Mongey/terraform-provider-kafka/
 

--- a/docker-compose.testacc.yaml
+++ b/docker-compose.testacc.yaml
@@ -9,7 +9,6 @@ services:
       - make
       - testacc
     depends_on:
-      - zookeeper
       - kafka1
       - kafka2
       - kafka3

--- a/kafka/client.go
+++ b/kafka/client.go
@@ -268,7 +268,7 @@ func (c *Client) UpdateTopic(topic Topic) error {
 	}
 
 	r := &sarama.AlterConfigsRequest{
-		Resources:    configToResources(topic),
+		Resources:    configToResources(topic, c.config),
 		ValidateOnly: false,
 	}
 

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -27,6 +27,7 @@ type Config struct {
 	ClientCert                             string
 	ClientCertKey                          string
 	ClientCertKeyPassphrase                string
+	IsAWSMSKServerless                     bool
 	KafkaVersion                           string
 	TLSEnabled                             bool
 	SkipTLSVerify                          bool
@@ -321,6 +322,7 @@ func (config *Config) copyWithMaskedSensitiveValues() Config {
 		config.ClientCert,
 		"*****",
 		"*****",
+		config.IsAWSMSKServerless,
 		config.KafkaVersion,
 		config.TLSEnabled,
 		config.SkipTLSVerify,

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"fmt"
 	"log"
+	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -209,6 +210,7 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ClientCert:                             d.Get("client_cert").(string),
 		ClientCertKey:                          d.Get("client_key").(string),
 		ClientCertKeyPassphrase:                d.Get("client_key_passphrase").(string),
+		IsAWSMSKServerless:                     false,
 		KafkaVersion:                           d.Get("kafka_version").(string),
 		SkipTLSVerify:                          d.Get("skip_tls_verify").(bool),
 		SASLAWSRegion:                          d.Get("sasl_aws_region").(string),
@@ -228,6 +230,13 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SASLMechanism:                          saslMechanism,
 		TLSEnabled:                             d.Get("tls_enabled").(bool),
 		Timeout:                                d.Get("timeout").(int),
+	}
+
+	re := regexp.MustCompile(`(?i)kafka-serverless\.(.*)\.amazonaws\.com`)
+	for _, broker := range *brokers {
+		if re.MatchString(broker) {
+			config.IsAWSMSKServerless = true
+		}
 	}
 
 	if config.CACert == "" {

--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -46,14 +46,15 @@ func ReplicaCount(c sarama.Client, topic string, partitions []int32) (int, error
 
 }
 
-func configToResources(topic Topic) []*sarama.AlterConfigsResource {
-	ConfigMSKServerless := topic.Config
-	delete(ConfigMSKServerless, "cleanup.policy")
+func configToResources(topic Topic, c *Config) []*sarama.AlterConfigsResource {
+	if c.IsAWSMSKServerless && topic.Config["cleanup.policy"] != nil {
+		delete(topic.Config, "cleanup.policy")
+	}
 	return []*sarama.AlterConfigsResource{
 		{
 			Type:          sarama.TopicResource,
 			Name:          topic.Name,
-			ConfigEntries: ConfigMSKServerless,
+			ConfigEntries: topic.Config,
 		},
 	}
 }

--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -47,11 +47,13 @@ func ReplicaCount(c sarama.Client, topic string, partitions []int32) (int, error
 }
 
 func configToResources(topic Topic) []*sarama.AlterConfigsResource {
+	ConfigMSKServerless := topic.Config
+	delete(ConfigMSKServerless, "cleanup.policy")
 	return []*sarama.AlterConfigsResource{
 		{
 			Type:          sarama.TopicResource,
 			Name:          topic.Name,
-			ConfigEntries: topic.Config,
+			ConfigEntries: ConfigMSKServerless,
 		},
 	}
 }


### PR DESCRIPTION
Based on https://github.com/Mongey/terraform-provider-kafka/pull/451 by @iamnotabout .

This PR fixes compatibility by omitting `cleanup.policy` which can't be changed in MSK Serverless.

Check for MSK Serverless based off DNS of the brokers (AWS mentions the pattern DNS prefix `kafka-serverless.Region.amazonaws.com` in their [instructions for connecting across VPCs](https://aws.amazon.com/blogs/big-data/secure-connectivity-patterns-for-amazon-msk-serverless-cross-account-access/#:~:text=As%20discussed%20earlier,%20the%20bootstrap%20server%20FQDN%20format%20is); I've seen it [elsewhere](https://www.google.com/search?q=kafka-serverless.Region.amazonaws.com) too). It seems like a reliable source to distinguish an MSK serverless connection.

Pending: testing

closes https://github.com/Mongey/terraform-provider-kafka/issues/446
