### PR TITLE
Fix Lazy evaluation of broker configuration

### DIFF
--- a/kafka/config.go
+++ b/kafka/config.go
@@ -27,7 +27,6 @@ type Config struct {
 	ClientCert                             string
 	ClientCertKey                          string
 	ClientCertKeyPassphrase                string
-	IsAWSMSKServerless                     bool
 	KafkaVersion                           string
 	TLSEnabled                             bool
 	SkipTLSVerify                          bool
@@ -322,7 +321,6 @@ func (config *Config) copyWithMaskedSensitiveValues() Config {
 		config.ClientCert,
 		"*****",
 		"*****",
-		config.IsAWSMSKServerless,
 		config.KafkaVersion,
 		config.TLSEnabled,
 		config.SkipTLSVerify,

--- a/kafka/provider.go
+++ b/kafka/provider.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"fmt"
 	"log"
-	"regexp"
 
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
 )
@@ -210,7 +209,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		ClientCert:                             d.Get("client_cert").(string),
 		ClientCertKey:                          d.Get("client_key").(string),
 		ClientCertKeyPassphrase:                d.Get("client_key_passphrase").(string),
-		IsAWSMSKServerless:                     false,
 		KafkaVersion:                           d.Get("kafka_version").(string),
 		SkipTLSVerify:                          d.Get("skip_tls_verify").(bool),
 		SASLAWSRegion:                          d.Get("sasl_aws_region").(string),
@@ -230,13 +228,6 @@ func providerConfigure(d *schema.ResourceData) (interface{}, error) {
 		SASLMechanism:                          saslMechanism,
 		TLSEnabled:                             d.Get("tls_enabled").(bool),
 		Timeout:                                d.Get("timeout").(int),
-	}
-
-	re := regexp.MustCompile(`(?i)kafka-serverless\.(.*)\.amazonaws\.com`)
-	for _, broker := range *brokers {
-		if re.MatchString(broker) {
-			config.IsAWSMSKServerless = true
-		}
 	}
 
 	if config.CACert == "" {

--- a/kafka/topic.go
+++ b/kafka/topic.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"errors"
 	"fmt"
+	"regexp"
 
 	"github.com/IBM/sarama"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -47,8 +48,14 @@ func ReplicaCount(c sarama.Client, topic string, partitions []int32) (int, error
 }
 
 func configToResources(topic Topic, c *Config) []*sarama.AlterConfigsResource {
-	if c.IsAWSMSKServerless && topic.Config["cleanup.policy"] != nil {
-		delete(topic.Config, "cleanup.policy")
+	if topic.Config["cleanup.policy"] != nil {
+		re := regexp.MustCompile(`(?i)kafka-serverless\.(.*)\.amazonaws\.com`)
+		for _, broker := range *c.BootstrapServers {
+			if re.MatchString(broker) {
+				// MSK Serverless does not support updating cleanup.policy
+				delete(topic.Config, "cleanup.policy")
+			}
+		}
 	}
 	return []*sarama.AlterConfigsResource{
 		{


### PR DESCRIPTION
Move the MSK check logic to inside the config update. We've already used the brokers in connection logic at this point.

https://github.com/Mongey/terraform-provider-kafka/issues/553