### PR TITLE
Remove `segment.bytes` from AWS MSK Serverless response

### DIFF
--- a/kafka/client.go
+++ b/kafka/client.go
@@ -5,8 +5,6 @@ import (
 	"fmt"
 	"log"
 	"math/rand"
-	"regexp"
-	"slices"
 	"sync"
 	"time"
 
@@ -637,13 +635,10 @@ func (c *Client) topicConfig(topic string) (map[string]*string, error) {
 				log.Printf("[TRACE] Syonyms: %v", s)
 			}
 
-			if tConf.Name == "segment.bytes" {
-				re := regexp.MustCompile(`(?i)kafka-serverless\.(.*)\.amazonaws\.com`)
-				if slices.ContainsFunc(*(c.config.BootstrapServers), re.MatchString) {
-					// Remove segment.bytes in AWS MSK Serverless response to prevent perpetual planning
-					log.Printf("[TRACE] [%s] Using AWS MSK Serverless. Skipping segment.bytes config", topic)
-					continue
-				}
+			if tConf.Name == "segment.bytes" && c.config.isAWSMSKServerless() {
+				// Remove segment.bytes in AWS MSK Serverless response to prevent perpetual planning
+				log.Printf("[TRACE] [%s] Using AWS MSK Serverless. Skipping segment.bytes config", topic)
+				continue
 			}
 
 			if isDefault(tConf, int(cr.Version)) {

--- a/kafka/config.go
+++ b/kafka/config.go
@@ -8,6 +8,8 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -344,4 +346,9 @@ func (config *Config) copyWithMaskedSensitiveValues() Config {
 		config.SASLOAuthScopes,
 	}
 	return copy
+}
+
+func (config *Config) isAWSMSKServerless() bool {
+	re := regexp.MustCompile(`(?i)kafka-serverless\.(.*)\.amazonaws\.com`)
+	return slices.ContainsFunc(*(config.BootstrapServers), re.MatchString)
 }

--- a/kafka/topic_test.go
+++ b/kafka/topic_test.go
@@ -1,0 +1,101 @@
+package kafka
+
+import (
+	"testing"
+
+	"github.com/IBM/sarama"
+)
+
+func TestConfigToResources_RemovesCleanupPolicyForAWSMSKServerless(t *testing.T) {
+	tests := []struct {
+		name                string
+		topic               Topic
+		config              *Config
+		expectCleanupPolicy bool
+	}{
+		{
+			name: "AWS MSK Serverless - cleanup.policy removed",
+			topic: Topic{
+				Name: "test-topic",
+				Config: map[string]*string{
+					"cleanup.policy": stringPtr("delete"),
+					"retention.ms":   stringPtr("604800000"),
+				},
+			},
+			config: &Config{
+				BootstrapServers: &[]string{"kafka-serverless.us-east-1.amazonaws.com:9092"},
+			},
+			expectCleanupPolicy: false,
+		},
+		{
+			name: "Non-MSK Serverless - cleanup.policy retained",
+			topic: Topic{
+				Name: "test-topic",
+				Config: map[string]*string{
+					"cleanup.policy": stringPtr("delete"),
+					"retention.ms":   stringPtr("604800000"),
+				},
+			},
+			config: &Config{
+				BootstrapServers: &[]string{"localhost:9092"},
+			},
+			expectCleanupPolicy: true,
+		},
+		{
+			name: "AWS MSK Serverless - no cleanup.policy to remove",
+			topic: Topic{
+				Name: "test-topic",
+				Config: map[string]*string{
+					"retention.ms": stringPtr("604800000"),
+				},
+			},
+			config: &Config{
+				BootstrapServers: &[]string{"kafka-serverless.us-east-1.amazonaws.com:9092"},
+			},
+			expectCleanupPolicy: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Make a copy of the config map to check original isn't modified
+			originalConfigLen := len(tt.topic.Config)
+
+			resources := configToResources(tt.topic, tt.config)
+
+			if len(resources) != 1 {
+				t.Errorf("Expected 1 resource, got %d", len(resources))
+				return
+			}
+
+			resource := resources[0]
+
+			// Check resource type and name
+			if resource.Type != sarama.TopicResource {
+				t.Errorf("Expected TopicResource type, got %v", resource.Type)
+			}
+
+			if resource.Name != tt.topic.Name {
+				t.Errorf("Expected topic name %s, got %s", tt.topic.Name, resource.Name)
+			}
+
+			// Check if cleanup.policy is present or removed as expected
+			_, hasCleanupPolicy := resource.ConfigEntries["cleanup.policy"]
+			if hasCleanupPolicy != tt.expectCleanupPolicy {
+				t.Errorf("Expected cleanup.policy presence to be %v, but was %v", tt.expectCleanupPolicy, hasCleanupPolicy)
+			}
+
+			// Verify the original topic config was modified (removed cleanup.policy for MSK serverless)
+			if tt.config.isAWSMSKServerless() && originalConfigLen > len(tt.topic.Config) {
+				if _, stillHasCleanupPolicy := tt.topic.Config["cleanup.policy"]; stillHasCleanupPolicy {
+					t.Error("Expected cleanup.policy to be removed from original topic config for AWS MSK Serverless")
+				}
+			}
+		})
+	}
+}
+
+// Helper function to create string pointers
+func stringPtr(s string) *string {
+	return &s
+}


### PR DESCRIPTION
# Overview

When using this provider against AWS MSK Serverless we often get a perpetual change on the `segment.bytes` configuration. The kafka terraform provider wants to reset the value to `null`. From what I can tell, this probably occurs when AWS MSK Serverless sets `segment.bytes` to a non default value. This results in a perpetual change in the terraform plan since `segment.bytes` is a managed property set by AWS (see [Configuration properties for MSK Serverless clusters](https://docs.aws.amazon.com/msk/latest/developerguide/serverless-config.html)).

An `ignore_changes` is inappropriate here since one would have to ignore the complete topic configuration, which may be desirable to change.

This change fixes the perpetual plan by removing the `segment.bytes` configuration in the case of MSK serverless brokers (identified by their DNS strings) when reading in the topic configuration. By doing so the read configuration produces null for `segment.bytes`, which matches an expected config block for MSK serverless.

----

## Example of perpetual change:

Plan against an MSK Serverless cluster with existing topics and no user changes since last apply. Using v0.10.3 provider from terraform registry.

<img width="968" height="271" alt="Screenshot 2025-07-22 at 08 46 47" src="https://github.com/user-attachments/assets/0f83a4cc-aca1-41f3-a7e8-d2cc7debde17" />

----

## Plan with these changes:

I did the same plan as above, but used a provider binary compiled from this PR.

We see the new log line in the debug logs:

<img width="649" height="48" alt="Screenshot 2025-07-22 at 08 50 42" src="https://github.com/user-attachments/assets/26eddd07-1263-4132-b86d-1bd593a07b7c" />

We see there are now no changes:

<img width="711" height="98" alt="Screenshot 2025-07-22 at 08 51 05" src="https://github.com/user-attachments/assets/31c8a6cd-c3ad-46c2-9ac7-72054b3ddd42" />
