### PR TITLE
fix: verify ACL resources with targeted describe requests

### DIFF
--- a/kafka/kafka_acls.go
+++ b/kafka/kafka_acls.go
@@ -417,6 +417,7 @@ func (c *Client) DescribeACLs(s StringlyTypedACL) ([]*sarama.ResourceAcls, error
 	}
 
 	r := &sarama.DescribeAclsRequest{
+		Version:   int(c.getDescribeAclsRequestAPIVersion()),
 		AclFilter: aclFilter,
 	}
 

--- a/kafka/lazy_client.go
+++ b/kafka/lazy_client.go
@@ -146,6 +146,14 @@ func (c *LazyClient) ListACLs() ([]*sarama.ResourceAcls, error) {
 	return c.inner.ListACLs()
 }
 
+func (c *LazyClient) DescribeACLs(s StringlyTypedACL) ([]*sarama.ResourceAcls, error) {
+	err := c.init()
+	if err != nil {
+		return nil, err
+	}
+	return c.inner.DescribeACLs(s)
+}
+
 func (c *LazyClient) DeleteACL(s StringlyTypedACL) error {
 	err := c.init()
 	if err != nil {

--- a/kafka/resource_kafka_acl.go
+++ b/kafka/resource_kafka_acl.go
@@ -121,7 +121,7 @@ func aclRead(ctx context.Context, d *schema.ResourceData, meta interface{}) diag
 	a := aclInfo(d)
 	log.Printf("[INFO] Reading ACL %s", a)
 
-	currentACLs, err := c.ListACLs()
+	currentACLs, err := c.DescribeACLs(a)
 	if err != nil {
 		return diag.FromErr(err)
 	}
@@ -236,10 +236,11 @@ func waitForACLToBeVisible(ctx context.Context, c *LazyClient, expectedACL Strin
 			return fmt.Errorf("failed to invalidate ACL cache: %w", err)
 		}
 
-		// List all ACLs
-		acls, err := c.ListACLs()
+		// Describe only the ACL we just created instead of issuing a broad
+		// "list everything" DescribeAcls probe.
+		acls, err := c.DescribeACLs(expectedACL)
 		if err != nil {
-			return fmt.Errorf("failed to list ACLs: %w", err)
+			return fmt.Errorf("failed to describe ACLs: %w", err)
 		}
 
 		// Check if our ACL exists
@@ -301,10 +302,11 @@ func waitForACLToBeDeleted(ctx context.Context, c *LazyClient, deletedACL String
 			return fmt.Errorf("failed to invalidate ACL cache: %w", err)
 		}
 
-		// List all ACLs
-		acls, err := c.ListACLs()
+		// Describe only the ACL we just deleted instead of issuing a broad
+		// "list everything" DescribeAcls probe.
+		acls, err := c.DescribeACLs(deletedACL)
 		if err != nil {
-			return fmt.Errorf("failed to list ACLs: %w", err)
+			return fmt.Errorf("failed to describe ACLs: %w", err)
 		}
 
 		// Check if our ACL still exists

--- a/kafka/resource_kafka_acl_test.go
+++ b/kafka/resource_kafka_acl_test.go
@@ -111,7 +111,22 @@ func testAccCheckAclDestroy(name string) error {
 	if err != nil {
 		return err
 	}
-	acls, err := client.ListACLs()
+
+	acl := StringlyTypedACL{
+		ACL: ACL{
+			Principal:      "User:Alice",
+			Host:           "*",
+			Operation:      "Write",
+			PermissionType: "Allow",
+		},
+		Resource: Resource{
+			Type:              "Topic",
+			Name:              name,
+			PatternTypeFilter: "Literal",
+		},
+	}
+
+	acls, err := client.DescribeACLs(acl)
 	if err != nil {
 		return err
 	}
@@ -149,7 +164,8 @@ func testResourceACL_initialCheck(s *terraform.State) error {
 		return err
 	}
 
-	acls, err := client.ListACLs()
+	expectedACL := testACLFromState(instanceState)
+	acls, err := client.DescribeACLs(expectedACL)
 	if err != nil {
 		return err
 	}
@@ -189,20 +205,6 @@ func testResourceACL_initialCheck(s *terraform.State) error {
 }
 
 func testResourceACL_updateCheck(s *terraform.State) error {
-	client := testProvider.Meta().(*LazyClient)
-	err := client.InvalidateACLCache()
-	if err != nil {
-		return err
-	}
-	acls, err := client.ListACLs()
-	if err != nil {
-		return err
-	}
-
-	if len(acls) < 1 {
-		return fmt.Errorf("there should be some acls %v %s", acls, err)
-	}
-
 	resourceState := s.Modules[0].Resources["kafka_acl.test"]
 	if resourceState == nil {
 		return fmt.Errorf("resource not found in state")
@@ -210,6 +212,22 @@ func testResourceACL_updateCheck(s *terraform.State) error {
 	instanceState := resourceState.Primary
 	if instanceState == nil {
 		return fmt.Errorf("resource has no primary instance")
+	}
+
+	client := testProvider.Meta().(*LazyClient)
+	err := client.InvalidateACLCache()
+	if err != nil {
+		return err
+	}
+
+	expectedACL := testACLFromState(instanceState)
+	acls, err := client.DescribeACLs(expectedACL)
+	if err != nil {
+		return err
+	}
+
+	if len(acls) < 1 {
+		return fmt.Errorf("there should be some acls %v %s", acls, err)
 	}
 
 	name := instanceState.Attributes["resource_name"]
@@ -250,6 +268,22 @@ func testResourceACL_updateCheck(s *terraform.State) error {
 		return fmt.Errorf("should be Prefixed, not %v", acl.ResourcePatternType)
 	}
 	return nil
+}
+
+func testACLFromState(instanceState *terraform.InstanceState) StringlyTypedACL {
+	return StringlyTypedACL{
+		ACL: ACL{
+			Principal:      instanceState.Attributes["acl_principal"],
+			Host:           instanceState.Attributes["acl_host"],
+			Operation:      instanceState.Attributes["acl_operation"],
+			PermissionType: instanceState.Attributes["acl_permission_type"],
+		},
+		Resource: Resource{
+			Type:              instanceState.Attributes["resource_type"],
+			Name:              instanceState.Attributes["resource_name"],
+			PatternTypeFilter: instanceState.Attributes["resource_pattern_type_filter"],
+		},
+	}
 }
 
 const testResourceACL_initialConfig = `


### PR DESCRIPTION
See #661

## Summary

`kafka_acl` creation can succeed, but the provider may fail immediately afterward during verification with an error like:

```text
ACL created but not visible: failed to list ACLs: kafka server: This most likely occurs because of a request being malformed by the client library or the message was sent to an incompatible broker. See the broker logs for more details
```

In my case (with Redpanda Self-Hosted) the ACLs were actually created successfully and visible via `rpk`, but Terraform/OpenTofu still failed because the provider could not confirm them.

## What I observed

The provider appears to:

1. create the ACL successfully
2. invalidate the ACL cache
3. call a broad ACL listing path for verification
4. fail on that broad list/read path
5. return an error even though the ACL now exists

I was able to confirm the ACLs existed immediately after the failed apply.

## Why I think this is happening

The current ACL verification/read path uses broad `DescribeAcls` listing behavior rather than a targeted describe for the specific ACL being created/read/deleted.

That broad listing path appears to be more fragile than necessary, both from a permission as well as a compatibility standpoint. In my case, it caused the provider to fail post-create verification even though the ACL was present.

There is also an inconsistency where targeted `DescribeAcls` did not explicitly set the request version, while the list path did.

## Suggested fix

Use targeted `DescribeACLs(...)` when verifying an ACL after create/delete and when reading a specific `kafka_acl`, instead of using `ListACLs()`.

Also explicitly set the `DescribeAclsRequest.Version` in the targeted describe path.

## Reproduction shape

- create `kafka_acl`
- provider returns:
  - `ACL created but not visible`
  - or `failed to list ACLs`
- broker-side tooling confirms the ACL exists

## Environment

- Provider: `Mongey/kafka` `v0.13.1`
- OpenTofu: `v1.10.7`

## Additional note

I have a local patch that switches ACL verification/read from broad ACL listing to targeted describe requests and explicitly sets the describe request version. That resolved the issue in my environment.
