### PR TITLE
fix: tolerate unsupported ACL resource types when listing (Redpanda)

### DIFF
--- a/kafka/kafka_acls.go
+++ b/kafka/kafka_acls.go
@@ -526,6 +526,16 @@ func (c *Client) ListACLs() ([]*sarama.ResourceAcls, error) {
 		log.Printf("[TRACE] ThrottleTime: %d", aclsR.ThrottleTime)
 
 		if aclsR.Err != sarama.ErrNoError {
+			// Some Kafka-API-compatible brokers (notably Redpanda) do not implement
+			// every ACL resource type. Redpanda rejects DescribeAcls for the
+			// DelegationToken resource type with INVALID_REQUEST, which would otherwise
+			// abort listing all ACLs and break refresh/plan/import against such brokers.
+			// Treat an unsupported resource type as "no ACLs of this type" and skip it
+			// instead of failing the whole listing. Real Kafka returns NoError here.
+			if aclsR.Err == sarama.ErrInvalidRequest || aclsR.Err == sarama.ErrUnsupportedVersion {
+				log.Printf("[WARN] Broker does not support DescribeAcls for resource type %v (%s); skipping this resource type", r.AclFilter.ResourceType, aclsR.Err)
+				continue
+			}
 			return nil, fmt.Errorf("%s", aclsR.Err)
 		}
 


### PR DESCRIPTION
# fix: tolerate unsupported ACL resource types when listing (Redpanda)

## Background

[Redpanda](https://redpanda.com/) is a streaming data platform that is a drop-in alternative to Apache Kafka: it speaks the same Kafka protocol and exposes a mostly identical API, so existing Kafka clients and tooling — including this provider — talk to it unchanged. Because the API is "mostly" identical rather than fully, a few rarely-used corners differ, and ACL listing happens to hit one of them (see below).

## Summary

`ListACLs()` enumerates `DescribeAcls` for every ACL resource type, including `DelegationToken`. Redpanda does not implement the `DelegationToken` resource type and rejects that specific request with `INVALID_REQUEST`. Because the listing loop returns on the first broker error, a single unsupported resource type aborts the **entire** ACL listing — which breaks `refresh`, `plan`, `apply` and `import` against Redpanda brokers, even though every other resource type (Topic, Group, Cluster, TransactionalID) is handled correctly.

This PR makes the listing skip a resource type when the broker reports it as unsupported (`INVALID_REQUEST` / `UNSUPPORTED_VERSION`) instead of failing the whole operation. Apache Kafka returns `NoError` for these types, so its behaviour is unchanged.

## Symptom

Any `plan`/`apply` against a Redpanda cluster fails on the read/refresh step:

```
Error: failed to list ACLs: kafka server: This most likely occurs because of a
request being malformed by the client library or the message was sent to an
incompatible broker. See the broker logs for more details
```

`CreateAcls` succeeds, so ACLs are actually written to the broker, but the provider can never read them back — leaving Terraform unable to manage them.

## Root cause

`kafka/kafka_acls.go` → `ListACLs()` issues one `DescribeAclsRequest` per resource type (Topic, Group, Cluster, TransactionalID, **DelegationToken**) and aborts on the first error:

```go
if aclsR.Err != sarama.ErrNoError {
    return nil, fmt.Errorf("%s", aclsR.Err)
}
```

Enabling trace logging on the broker shows exactly which request is rejected (Redpanda v26.1.8). Resource types `2/3/4/5` return `none`; type `6` (DelegationToken) returns `invalid_request`:

```
handling describe_acls v1 request {resource_type=6 ...}
describe_acls.cc:100 - Error describing ACLs: Invalid resource type: 6
sending 29:describe_acls ... error_code={ invalid_request [42] }
                          error_message={Invalid resource type: 6}
```

## Fix

Skip a resource type when the broker reports it as unsupported, instead of failing the whole listing:

```go
if aclsR.Err != sarama.ErrNoError {
    if aclsR.Err == sarama.ErrInvalidRequest || aclsR.Err == sarama.ErrUnsupportedVersion {
        log.Printf("[WARN] Broker does not support DescribeAcls for resource type %v (%s); skipping this resource type", r.AclFilter.ResourceType, aclsR.Err)
        continue
    }
    return nil, fmt.Errorf("%s", aclsR.Err)
}
```

- Real Kafka returns `NoError` for all five resource types → the new branch is never taken → no behavioural change.
- Redpanda returns `INVALID_REQUEST` for DelegationToken → it is skipped (and logged), and the remaining types are listed normally.
- The skip is intentionally scoped to "broker doesn't support this resource type" error codes; any other error still aborts the listing as before.

## Testing

Verified end-to-end against a local stack pinned to production versions, using a locally built provider via `dev_overrides`:

| Broker | Version | Authorizer | `apply` | idempotent re-`plan` |
|---|---|---|---|---|
| Redpanda | v26.1.8 | native | ✅ 7 ACLs created | ✅ `No changes` |
| Apache Kafka (KRaft) | 3.9 / cp 7.9.6 | StandardAuthorizer | ✅ | ✅ `No changes` (no regression) |
| Apache Kafka (ZooKeeper) | 2.7 / cp 6.1.0 | SimpleAclAuthorizer | ✅ | ✅ `No changes` |

Before the fix, Redpanda failed on the list/refresh step as shown above; after the fix it manages ACLs cleanly with a stable, drift-free plan.

## Backward compatibility

No configuration changes. No change in behaviour against Apache Kafka. The only difference is that brokers which reject a resource type as unsupported are now tolerated instead of breaking the whole ACL listing.
